### PR TITLE
[Infra] Avoid downloading things from the internet for Git-LFS

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,3 @@
+[lfs]
+	url = https://github.com/canonical/yarf.git/info/lfs
+	pushurl = ssh://git@github.com/canonical/yarf.git

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   apt_packages:
+    - git-lfs
     - libxkbcommon-dev
   tools:
     python: "3.12"
@@ -25,20 +26,10 @@ build:
         then
           exit 183;
         fi
-      # Support Git LFS: Download and uncompress the binary
-      # https://docs.readthedocs.io/en/stable/build-customization.html#support-git-lfs-large-file-storage
-      - wget https://github.com/git-lfs/git-lfs/releases/download/v3.5.1/git-lfs-linux-amd64-v3.5.1.tar.gz
-      - tar xvfz git-lfs-linux-amd64-v3.5.1.tar.gz
-      # Modify LFS config paths to point where git-lfs binary was downloaded
-      - git config filter.lfs.process "`pwd`/git-lfs-3.5.1/git-lfs filter-process"
-      - git config filter.lfs.smudge  "`pwd`/git-lfs-3.5.1/git-lfs smudge -- %f"
-      - git config filter.lfs.clean "`pwd`/git-lfs-3.5.1/git-lfs clean -- %f"
-      # Make LFS available in current repository
-      - ./git-lfs-3.5.1/git-lfs install
-      # Download content from remote
-      - ./git-lfs-3.5.1/git-lfs fetch
-      # Make local files to have the real content on them
-      - ./git-lfs-3.5.1/git-lfs checkout
+    post_system_dependencies:
+      - git lfs install
+      - git lfs fetch
+      - git lfs checkout
     pre_build:
       - cd docs && make libdoc-convert
 


### PR DESCRIPTION
## Description
`git-lfs` is supported in the archive, no need to pull it from random places on the Internet.

## Resolved issues
N/A

## Documentation
Yes.

## Tests
CI will blend