### PR TITLE
[New] Add PR traceability marker check

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,26 @@
+name: PR Validation
+permissions:
+  contents: read
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - edited
+
+jobs:
+  validate_title:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checking the presence of the Traceability Marker in the PR title
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        echo "$PR_TITLE" | awk '
+        /^\[(New|Breaking|Infra|BugFix)\]/ {
+            print "Starts with a recognized tag"
+            next
+        }
+        {
+            print "No recognized tag"
+        }'


### PR DESCRIPTION
## Description

This PR adds a `pr-validation` CI, which currently just checks the traceability marker in a PR's title.
This marker is important for dynamic versioning, since we will determine the version of YARF based on these tags.

## Resolved issues

Part of [YARF-50](https://warthogs.atlassian.net/browse/YARF-50)

## Documentation


## Tests


