### PR TITLE
[BugFix] Use keywords without specifying library names

### DIFF
--- a/docs/tutorial/getting_started.md
+++ b/docs/tutorial/getting_started.md
@@ -204,9 +204,9 @@ Now let's use the YARF interactive mode to do some simple maths. With the cursor
 
 ```{code-block} bash
 ---
-caption: Using the command `PlatformHid.Type String`.
+caption: Using the command `Type String`.
 ---
-> PlatformHid.Type String   7*6=
+> Type String   7*6=
 > 
 ```
 

--- a/docs/tutorial/writting-a-test-suite.md
+++ b/docs/tutorial/writting-a-test-suite.md
@@ -77,7 +77,7 @@ To work on the five testing steps we discussed earlier, we can identify from the
 1. `Match Text`: Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using `RPA.core.geometry.to_region`. We can use this keyword to check the count is what we expected.
 1. `Keys Combo`: Press and release a combination of keys. :param combo: list of keys to press at the same time. We can use this to close the application by pressing `Alt + F4`.
 
-`PlatformVideoInput.Match` and `Click ${button} Button On ${destination}` use template matching, so we need to provide templates for these two keywords. In interactive mode, we provided a `Grab Templates` keyword that opens an ROI selector to allow our users to select templates.
+`Match` and `Click ${button} Button On ${destination}` use template matching, so we need to provide templates for these two keywords. In interactive mode, we provided a `Grab Templates` keyword that opens an ROI selector to allow our users to select templates.
 
 ```{figure} ./images/roi_selector_selecting_templates.png
 ---
@@ -122,26 +122,26 @@ Now, let's test our keywords and templates:
 ---
 caption: Testing out different keywords.
 ---
-> PlatformVideoInput.Match   template=/path/to/simple_counter.png
+> Match   template=/path/to/simple_counter.png
 ...
 < [{'left': 316, 'top': 182, 'right': 624, 'bottom': 407, 'path': '/path/to/simple_counter.png'}]
 > Click LEFT Button on /path/to/+.png                                                                       # ΔT: 0.141s
 INFO:root:Scanned image in 0.10 seconds
-> PlatformVideoInput.Match Text   text=Count: 1                                                             # ΔT: 0.084s
+> Match Text   text=Count: 1                                                                                # ΔT: 0.084s
 < ([{'text': 'Count: 1', 'region': Region(left=416, top=250, right=525, bottom=281), 'confidence': 100.0}], <PIL.Image.Image image mode=RGBA size=1280x1024 at 0x7011F836AE40>)
 > Click LEFT Button on /path/to/-.png                                                                       # ΔT: 0.374s
 INFO:root:Scanned image in 0.07 seconds
-> PlatformVideoInput.Match Text   text=Count: 0
+> Match Text   text=Count: 0
 < ([{'text': 'Count: 0', 'region': Region(left=415, top=248, right=526, bottom=281), 'confidence': 100.0}], <PIL.Image.Image image mode=RGBA size=1280x1024 at 0x7011F81CB4D0>)
 > Click LEFT Button on /path/to/toggle_theme.png                                                            # ΔT: 0.090s
 INFO:root:Scanned image in 0.08 seconds
-> PlatformHid.Move Pointer To Absolute  x=0  y=0   # This is to move away the pointer from the application.
+> Move Pointer To Absolute  x=0  y=0   # This is to move away the pointer from the application.
 >                                                                                                           # ΔT: 0.002s
 > Interactive.Grab Templates   simple_counter_toggled   # Grab the template for the simple counter in light theme here.
 ...
 Click and drag to select and save an ROI, press Esc to exit the ROI selector.
 ROI saved as /path/to/simple_counter_toggled.png
-> PlatformVideoInput.Match  /path/to/simple_counter_toggled.png
+> Match  /path/to/simple_counter_toggled.png
 INFO:root:Scanned image in 0.07 seconds
 < [{'left': 317, 'top': 177, 'right': 624, 'bottom': 407, 'path': '/path/to/simple_counter_toggled.png'}]
 >                                                                                                           # ΔT: 0.077s
@@ -191,7 +191,7 @@ Resource        kvm.resource
 
 *** Test Cases ***
 Assert simple counter started
-    PlatformVideoInput.Match                   ${CURDIR}/simple_counter.png
+    Match                   ${CURDIR}/simple_counter.png
 
 Increase the counter and assert count
     Click LEFT Button on ${CURDIR}/buttons/+.png
@@ -203,7 +203,7 @@ Decrease the counter and assert count
 
 Toggle theme and assert the theme changed
     Click LEFT Button on ${CURDIR}/buttons/toggle_theme.png
-    PlatformHid.Move Pointer To Absolute            x=0                     y=0
+    Move Pointer To Absolute            x=0                     y=0
     Match                   ${CURDIR}/simple_counter_toggled.png
 
 Close the simple counter

--- a/examples/yarf-example-simple-counter/yarf_tests/button_tests.robot
+++ b/examples/yarf-example-simple-counter/yarf_tests/button_tests.robot
@@ -25,7 +25,7 @@ Decrease the counter and assert count
 Toggle theme and assert the theme changed
     [Tags]                  yarf:certification_status: blocker
     Click LEFT Button on ${CURDIR}/buttons/toggle_theme.png
-    PlatformHid.Move Pointer To Absolute            x=0                     y=0
+    Move Pointer To Absolute                        x=0                     y=0
     Match                   ${CURDIR}/simple_counter_toggled.png
 
 Close the simple counter

--- a/yarf/output/tests/test_test_submission_schema.py
+++ b/yarf/output/tests/test_test_submission_schema.py
@@ -33,7 +33,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -47,7 +46,7 @@ class TestTestSubmissionSchema:
 
                     Task3
                         [Tags]                  yarf:certification_status: non-blocker        yarf:category_id: com.canonical.category::categoryC
-                        PlatformHid.Type String     1234567890
+                        Type String     1234567890
                     """
                 ),
                 "com.canonical.yarf",
@@ -67,7 +66,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -81,7 +79,7 @@ class TestTestSubmissionSchema:
 
                     Task3
                         [Tags]                  yarf:certification_status: non-blocker        yarf:category_id: com.canonical.category::categoryC
-                        PlatformHid.Type String     1234567890
+                        Type String     1234567890
                     """
                 ),
                 "com.sample.space",
@@ -124,7 +122,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -150,7 +147,6 @@ class TestTestSubmissionSchema:
                     f"""
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -177,7 +173,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -203,7 +198,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***
@@ -229,7 +223,6 @@ class TestTestSubmissionSchema:
                     """
                     *** Settings ***
                     Resource        kvm.resource
-                    Library         Hid.py    AS    PlatformHid
 
 
                     *** Test Cases ***

--- a/yarf/rf_libraries/interactive_console/Interactive.py
+++ b/yarf/rf_libraries/interactive_console/Interactive.py
@@ -52,7 +52,7 @@ class Interactive:
         Raises:
             ValueError: If the screenshot could not be grabbed.
         """
-        platform_video_input = self._get_lib_instance("PlatformVideoInput")
+        platform_video_input = self._get_lib_instance("VideoInput")
         if (image := await platform_video_input.grab_screenshot()) is None:
             raise ValueError("Failed to grab screenshot.")
 

--- a/yarf/rf_libraries/interactive_console/tests/test_interactive.py
+++ b/yarf/rf_libraries/interactive_console/tests/test_interactive.py
@@ -21,7 +21,7 @@ class TestInteractive:
         )
         await interactive.grab_templates(sentinel.template_names)
 
-        mock_get_lib_instance.assert_called_once_with("PlatformVideoInput")
+        mock_get_lib_instance.assert_called_once_with("VideoInput")
         sentinel.platform_video_input.grab_screenshot.assert_called_once()
         mock_ROISelector.assert_called_once_with(
             sentinel.image, sentinel.template_names

--- a/yarf/rf_libraries/resources/kvm.resource
+++ b/yarf/rf_libraries/resources/kvm.resource
@@ -2,12 +2,12 @@
 Documentation       Keyword definitions for specialised functionality
 ...                 for Keyboard, Mouse and Video-based manipulation.
 ...
-...                 These keywords rely on PlatformVideoInput library to be initialized
-...                 using the PlatformVideoInput.Init keyword. The initialization is
-...                 platform-specific.
+...                 These keywords rely on VideoInput and Hid libraries
+...                 to be initialized using the Init keyword.
+...                 The initialization is platform-specific.
 
-Library             Hid.py    AS    PlatformHid
-Library             VideoInput.py    AS    PlatformVideoInput
+Library             Hid.py
+Library             VideoInput.py
 Variables           video_input_vars.py
 
 
@@ -32,22 +32,16 @@ Press Combo And Match
     ...                     ${tolerance}=${DEFAULT_TEMPLATE_MATCHING_TOLERANCE}
 
     ${match}=               Run Keyword And Return Status
-    ...                     PlatformVideoInput.Match
-    ...                     ${template}
-    ...                     ${timeout}
-    ...                     ${tolerance}
+    ...                     Match                   ${template}             ${timeout}              ${tolerance}
     IF    ${match}
         Log                     Template is already matching.                   html=true               console=true
         RETURN
     END
 
     FOR    ${index}    IN RANGE    ${tentatives}
-        PlatformHid.Keys Combo                          ${keys-combo}
+        Keys Combo              ${keys-combo}
         ${match}=               Run Keyword And Return Status
-        ...                     PlatformVideoInput.Match
-        ...                     ${template}
-        ...                     ${timeout}
-        ...                     ${tolerance}
+        ...                     Match                   ${template}             ${timeout}              ${tolerance}
         IF    ${match}    BREAK
     END
 
@@ -61,7 +55,7 @@ Press And Wait For Match
     ...                     ${tolerance}=${DEFAULT_TEMPLATE_MATCHING_TOLERANCE}
 
     Keys Combo              ${keys-combo}
-    PlatformVideoInput.Match                        ${template}             ${timeout}              ${tolerance}
+    Match                   ${template}             ${timeout}              ${tolerance}
 
 Get Center Of ${region}
     [Documentation]    Get the center point of a region.
@@ -96,7 +90,7 @@ Move Pointer To (${x}, ${y})
     ...    Embedded arguments:
     ...    - ${x}: Integer absolute x-coordinate to move the pointer to.
     ...    - ${y}: Integer absolute y-coordinate to move the pointer to.
-    PlatformHid.Move Pointer To Absolute            ${x}                    ${y}
+    Move Pointer To Absolute                        ${x}                    ${y}
 
 Move Pointer To ${destination}
     [Documentation]    Move the pointer to an absolute position or image
@@ -115,7 +109,7 @@ Move Pointer To ${destination}
     ...    Absolute position of the pointer after the move, as a tuple (x, y)
     ...    of integers.
     IF    ${{ os.path.exists($destination) }}
-        ${regions}=             PlatformVideoInput.Match                        ${destination}
+        ${regions}=             Match                   ${destination}
         ${position}=            Get Center Of ${regions}[0]
     ELSE IF    ${{ isinstance($destination, tuple) }}
         ${position}=            Set Variable            ${destination}
@@ -124,10 +118,10 @@ Move Pointer To ${destination}
         ...                     Assuming ${destination} is a string as it isn't a file which exists.
         ...                     html=true
         ...                     console=true
-        ${position}=            PlatformVideoInput.Get Text Position            text=${destination}
+        ${position}=            Get Text Position       text=${destination}
     END
 
-    PlatformHid.Move Pointer To Absolute            ${position}[0]          ${position}[1]
+    Move Pointer To Absolute                        ${position}[0]          ${position}[1]
     RETURN                  ${position}
 
 Move Pointer To ${destination} In ${domain}
@@ -152,7 +146,7 @@ Move Pointer To ${destination} In ${domain}
         ${sub_region}=          Set Variable            ${domain}
     ELSE IF    ${{ isinstance(domain, str) }}
         IF    ${{ os.path.exists($domain) }}
-            ${sub_regions}=         PlatformVideoInput.Match                        ${domain}
+            ${sub_regions}=         Match                   ${domain}
             ${sub_region}=          Set Variable            ${sub_regions}[0]
         ELSE
             Fail                    Template ${domain} doesn't exist!
@@ -162,17 +156,17 @@ Move Pointer To ${destination} In ${domain}
     END
 
     IF    ${{ os.path.exists($destination) }}
-        ${regions}=             PlatformVideoInput.Match
+        ${regions}=             Match
         ...                     template=${destination}
         ...                     region=${sub_region}
         ${position}=            Get Center Of ${regions}[0]
     ELSE
-        ${position}=            PlatformVideoInput.Get Text Position
+        ${position}=            Get Text Position
         ...                     text=${destination}
         ...                     region=${sub_region}
     END
 
-    PlatformHid.Move Pointer To Absolute            ${position}[0]          ${position}[1]
+    Move Pointer To Absolute                        ${position}[0]          ${position}[1]
     RETURN                  ${position}
 
 Move Pointer To Proportional (${x}, ${y})
@@ -190,7 +184,7 @@ Move Pointer To Proportional (${x}, ${y})
     ...    Return:
     ...    Absolute position of the pointer after the move, as a tuple (x, y)
     ...    of integers.
-    ${position}=            PlatformHid.Move Pointer To Proportional        ${x}                    ${y}
+    ${position}=            Move Pointer To Proportional                    ${x}                    ${y}
     RETURN                  ${position}
 
 Walk Pointer To (${x}, ${y})
@@ -205,7 +199,7 @@ Walk Pointer To (${x}, ${y})
     ...    - ${delay} (optional): Time to sleep after each step, in seconds.
     ...    Default is 0.01.
     [Arguments]             ${step_distance}=16     ${delay}=0.01
-    PlatformHid.Walk Pointer To Absolute
+    Walk Pointer To Absolute
     ...                     ${x}
     ...                     ${y}
     ...                     ${step_distance}
@@ -232,12 +226,12 @@ Walk Pointer To ${destination}
     ...    of integers.
     [Arguments]             ${step_distance}=16     ${delay}=0.01
     IF    ${{isinstance($destination, str)}}
-        ${regions}=             PlatformVideoInput.Match                        ${destination}
+        ${regions}=             Match                   ${destination}
         ${position}=            Get Center Of ${regions}[0]
     ELSE
         ${position}=            Set Variable            ${destination}
     END
-    PlatformHid.Walk Pointer To Absolute
+    Walk Pointer To Absolute
     ...                     ${position}[0]
     ...                     ${position}[1]
     ...                     ${step_distance}
@@ -265,7 +259,7 @@ Walk Pointer To Proportional (${x}, ${y})
     ...    Absolute position of the pointer after the walk, as a tuple (x, y)
     ...    of integers.
     [Arguments]             ${step_distance}=16     ${delay}=0.01
-    ${position}=            PlatformHid.Walk Pointer To Proportional
+    ${position}=            Walk Pointer To Proportional
     ...                     ${x}
     ...                     ${y}
     ...                     ${step_distance}
@@ -277,21 +271,21 @@ Press ${button} Button
     ...
     ...    Embedded arguments:
     ...    - ${button}: Button to press (LEFT|RIGHT|MIDDLE).
-    PlatformHid.Press Pointer Button                ${button}
+    Press Pointer Button    ${button}
 
 Release ${button} Button
     [Documentation]    Release a button on the virtual pointer.
     ...
     ...    Embedded arguments:
     ...    - ${button}: Button to release (LEFT|RIGHT|MIDDLE).
-    PlatformHid.Release Pointer Button              ${button}
+    Release Pointer Button                          ${button}
 
 Click ${button} Button
     [Documentation]    Click a button on the virtual pointer.
     ...
     ...    Embedded arguments:
     ...    - ${button}: Button to click (LEFT|RIGHT|MIDDLE).
-    PlatformHid.Click Pointer Button                ${button}
+    Click Pointer Button    ${button}
 
 Click ${button} Button On ${destination}
     [Documentation]    Move the virtual pointer to the destination and click the button.
@@ -306,7 +300,7 @@ Click ${button} Button On ${destination}
 
 Release Buttons
     [Documentation]    Release all buttons on the virtual pointer.
-    PlatformHid.Release Pointer Buttons
+    Release Pointer Buttons
 
 Ensure ${destination} Does Not Match
     [Documentation]    Ensure a given template or string doesn't match within a given timeout and
@@ -322,18 +316,14 @@ Ensure ${destination} Does Not Match
 
     IF    ${{ os.path.exists($destination) }}
         ${match}=               Run Keyword And Return Status
-        ...                     PlatformVideoInput.Match
-        ...                     ${destination}
-        ...                     timeout=${timeout}
+        ...                     Match                   ${destination}          timeout=${timeout}
     ELSE
         Log
         ...                     Assuming ${destination} is a string as it isn't a file which exists.
         ...                     html=true
         ...                     console=true
         ${match}=               Run Keyword And Return Status
-        ...                     PlatformVideoInput.Match Text
-        ...                     ${destination}
-        ...                     timeout=${timeout}
+        ...                     Match Text              ${destination}          timeout=${timeout}
     END
     IF    ${match}
         Fail                    Found ${destination} where it wasn't intended or expected


### PR DESCRIPTION
## Description

When we use interactive mode, we need to specify the library name for some keywords. If not, an error will be prompted and ask the user to specify the library.
This PR directly imports libraries to kvm without aliasing them, so that all the keywords are unique.

## Resolved issues

[ISSUE-14](https://github.com/canonical/yarf/issues/14)
[YARF-45](https://warthogs.atlassian.net/browse/YARF-45)

## Documentation



## Tests

Try to start interactive mode with either Vnc or Mir and try out keywords like `Match` or `TypeString`, here I use an example with the `gnome-calculator`:
```
$ yarf --platform Mir


INFO: *** Welcome to the YARF interactive console. ***
INFO: You can use this console to execute Robot Framework keywords interactively.
INFO: The value of ${CURDIR} is CWD, you can change it using the `Set Variable` keyword.
INFO: You can press RIGHT_ARROW to auto-complete the keyword.
INFO: You can press CRTL + SPACE to view supported keywords on a prefix.
>>>>> Enter interactive shell
iRobot can interpret single or multiple keyword calls,
as well as FOR, IF, WHILE, TRY
and resource file syntax like *** Keywords*** or *** Variables ***.

Type "help" for more information.
> Match Text    2
< ([{'text': '10x4+2', 'region': Region(left=333, top=368, right=407, bottom=392), 'confidence': 100.0}, {'text': '2', 'region': Region(left=427, top=593, right=438, bottom=614), 'confidence': 100}], <PIL.Image.Image image mode=RGBA size=1280x1024 at 0x723BA467CBC0>)
>                                                                                                                                                                                                                                                         # ΔT: 0.717s
<<<<< Exit shell.
INFO:yarf.main:Interactive console log exported to: /tmp/yarf-outdir/rfdebug_history.log
Log:     /tmp/yarf-outdir/log.html
Report:  /tmp/yarf-outdir/report.html
