### PR TITLE
[BugFix] Fix URL anchor formats in generated library docs

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -7,10 +7,10 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   apt_packages:
     - git-lfs
-    - libxkbcommon-dev
+    - libxkbcommon-dev   # YARF deps require xkbcommon>=1.4.1, Ubuntu-22.04 only has 1.4.0
   tools:
     python: "3.12"
   jobs:


### PR DESCRIPTION
This pull request improves the `convert_libdoc_to_md.py` Markdown conversion script to clean up HTML anchor tags. The original `href` elements in description contain special characters that are not recognized by Sphinx-built HTML, which caused broken anchor links in the output and failure in accessiblity check.

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

* Added a new `fix_link_anchors` function that parses HTML text, decodes anchor fragments in URLs, and replaces special characters with dashes for consistent anchors.
  * For example, `href="#Move%20Pointer%20To%20%24%7Bdestination%7D"` is changed to ` href="#move-pointer-to-destination"`

It fixes the error reported by Pa11y check:

```
 > Running Pa11y on URL file:///yarf/docs/_build/reference/rf_libraries/resources/resource-kvm/index.html

Results for URL: file:///yarf/docs/_build/reference/rf_libraries/resources/resource-kvm/index.html

 • Error: This link points to a named anchor "Move%20Pointer%20To%20%24%7Bdestination%7D" within the document, but no anchor exists with that name.
   ├── WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID
   ├── #click-button-button-on-destination > p:nth-child(3) > a
   └── <a href="#Move%20Pointer%20To%20%24%7Bdestination%7D" class="name">Move Pointer to ${destination}</a>

1 Errors
```

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
(N/A)


## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->
(N/A)

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Under `docs/` path, running `make libdoc-convert` generates new library docs, where href with anchors are cleaned up.

For example, in `docs/reference/rf_libraries/resources/resource-kvm.md`:

```
### Click ${button} Button On ${destination}

<p>Move the virtual pointer to the destination and click the button.</p>
<p>See <a class="name" href="#move-pointer-to-destination">Move Pointer to ${destination}</a> for details.</p>
```

