### PR TITLE
[Infra] Update doc configuration to ignore check from certain files

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -7,10 +7,10 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   apt_packages:
     - git-lfs
-    - libxkbcommon-dev
+    - libxkbcommon-dev   # YARF deps require xkbcommon>=1.4.1, Ubuntu-22.04 only has 1.4.0
   tools:
     python: "3.12"
   jobs:

--- a/docs/.sphinx/pa11y.json
+++ b/docs/.sphinx/pa11y.json
@@ -5,5 +5,8 @@
     ]
   },
   "reporter": "cli",
-  "standard": "WCAG2AA"
+  "standard": "WCAG2AA",
+  "hideElements": [
+    "div.highlight pre"
+  ]
 }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -145,7 +145,7 @@ vale: vale-install
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 	@cat $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
-	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' $(TARGET)
+	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' --glob='!reference/rf_libraries/**' $(TARGET)
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 
 spelling: vale-install


### PR DESCRIPTION

## Description

* Doc accessibility check with `pa11y`:

  Updated the `pa11y.json` configuration to hide code blocks with syntax highlighting from accessibility checks. This resolves false-positive alerts with `insufficient contrast` on highlighted code blocks:
  ```
   • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 4.28:1. Recommendation:  change background to #f8f8f8.
     ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
     ├── #codecell4 > span:nth-child(54)
     └── <span class="o">=</span>
  ```

  Reference on CSS selector: https://github.com/pa11y/pa11y?tab=readme-ov-file#hideelements-string


* Doc style check with `vale`:
  Updated the `vale` command in `Makefile` to exclude `rf_libraries/` directory path from checking

  Reference on globbing: https://vale.sh/docs/guides/glob

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
N/A

## Documentation

N/A

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->
- `make pa11y` no longer reports `insufficient contrast` errors
- `make vale` no longer reports `Canonical.007-Headings-sentence-case` style errors
