### PR TITLE
[BugFix] Revert xkbcommon version update

### DIFF
--- a/.github/workflows/yarf.yaml
+++ b/.github/workflows/yarf.yaml
@@ -17,7 +17,33 @@ on:
       - '!.github/workflows/yarf.yaml'
 
 jobs:
-  build:
+  install-jammy:
+    runs-on: [self-hosted, linux, jammy, x64, large]
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq
+        sudo apt install -y \
+          git-lfs \
+          libgl1 \
+          libxkbcommon-dev \
+          jq \
+          clang \
+          python3-tk
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      with:
+        lfs: true
+        ref: ${{ inputs.ref }}
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      with:
+        python-version: "3.10"
+    - name: Install uv
+      run: pip install uv
+    - name: Sync Python dependencies
+      run: uv sync
+
+  test-noble:
     runs-on: [self-hosted, linux, noble, x64, large]
     steps:
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "robotframework-sshlibrary~=3.8.0",
     "robotframework-stacktrace==0.4.1",
     "numpy~=1.26.0",
-    "xkbcommon<1.6",
+    "xkbcommon<1.5",  # ubuntu jammy supports up to 1.4.0
     "pyte~=0.8.2",
     "pyserial>=3.5",
     "python-dateutil>=2.9.0.post0",

--- a/uv.lock
+++ b/uv.lock
@@ -1516,12 +1516,12 @@ wheels = [
 
 [[package]]
 name = "xkbcommon"
-version = "1.5.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/f6/6f304689f619323bfa64a8f3777da7b3108fdd513b6bf66e9438bf1c8a17/xkbcommon-1.5.1.tar.gz", hash = "sha256:ac174808dbf61d35d9da804bf33baac74bc6f2be0c108594ae93c79cd15ddc36", size = 80170, upload-time = "2024-07-07T09:45:22.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/29/fd4be2098b0a963c95d5f9cbd03bcf3f5bf741632a994395f62de6b4ef69/xkbcommon-1.0.1.tar.gz", hash = "sha256:9e9749d6ecba514161662a468ba38689ab6b6e962af42e09fba5eeabcb776c91", size = 79726, upload-time = "2024-07-05T21:45:34.803Z" }
 
 [[package]]
 name = "yarf"
@@ -1589,6 +1589,6 @@ requires-dist = [
     { name = "robotframework-stacktrace", specifier = "==0.4.1" },
     { name = "tox", marker = "extra == 'develop'" },
     { name = "types-python-dateutil", marker = "extra == 'develop'" },
-    { name = "xkbcommon", specifier = "<1.6" },
+    { name = "xkbcommon", specifier = "<1.5" },
 ]
 provides-extras = ["develop"]


### PR DESCRIPTION
## Description

The `xkbcommon` package is just a binding for `libxkbcommon`, which means we should stick to the version that gives us compatibility with both jammy and noble.

1. Revert to the previous version
2. Add a simple `uv sync` check on a Jammy runner

## Resolved issues

Resolves https://github.com/canonical/yarf/issues/38

## Documentation

Added an inline comment

## Tests

CI will do
