### PR TITLE
[Infra] Running pre-commit locally doesn't work with mypy/docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,9 @@ repos:
   rev: v1.15.0
   hooks:
   - id: mypy
-    language: system
     pass_filenames: false
+    additional_dependencies:
+    - types-python-dateutil
     args:
     - --check-untyped-defs
     - --ignore-missing-imports  # Ref.: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker
@@ -123,9 +124,12 @@ repos:
   hooks:
     - id: licensecheck
       name: licensecheck
-      entry: uv tool run licensecheck --zero --show-only-failing --requirements-paths=pyproject.toml
-      language: system
+      entry: licensecheck --zero --show-only-failing --requirements-paths=pyproject.toml
+      language: python
+      types: [python]
       pass_filenames: false
+      additional_dependencies:
+      - licensecheck
 
     - id: docs-spelling
       name: Docs spell check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Optionally, enable pre-commit checks, so your contribution will pass all the che
 we run on the code:
 
 ```shell
-uvx --from 'pre-commit<4.0.0' pre-commit install
+uvx pre-commit install
 ```
 
 We can start working on the repository here.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -138,7 +138,7 @@ vale: vale-install
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 	@cat $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
 	@echo "Running Vale against $(TARGET). To change target set TARGET= with make command"
-	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' --glob='!reference/rf_libraries/**' $(TARGET)
+	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' --glob='!{reference/rf_libraries,_build}/**' $(TARGET)
 	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
 
 spelling: vale-install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ develop = [
     "pytest-cov",
     "pytest-xdist",
     "tox",
-    "types-python-dateutil",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1428,15 +1428,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20250708"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/95/6bdde7607da2e1e99ec1c1672a759d42f26644bbacf939916e086db34870/types_python_dateutil-2.9.0.20250708.tar.gz", hash = "sha256:ccdbd75dab2d6c9696c350579f34cffe2c281e4c5f27a585b2a2438dd1d5c8ab", size = 15834, upload-time = "2025-07-08T03:14:03.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/52/43e70a8e57fefb172c22a21000b03ebcc15e47e97f5cb8495b9c2832efb4/types_python_dateutil-2.9.0.20250708-py3-none-any.whl", hash = "sha256:4d6d0cc1cc4d24a2dc3816024e502564094497b713f7befda4d5bc7a8e3fd21f", size = 17724, upload-time = "2025-07-08T03:14:02.593Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1568,7 +1559,6 @@ develop = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "tox" },
-    { name = "types-python-dateutil" },
 ]
 
 [package.metadata]
@@ -1598,7 +1588,6 @@ requires-dist = [
     { name = "robotframework-sshlibrary", specifier = "~=3.8.0" },
     { name = "robotframework-stacktrace", specifier = "==0.4.1" },
     { name = "tox", marker = "extra == 'develop'" },
-    { name = "types-python-dateutil", marker = "extra == 'develop'" },
     { name = "xkbcommon", specifier = "<1.5" },
 ]
 provides-extras = ["develop"]


### PR DESCRIPTION
## Description

After the latest changes, I'm experiencing some issues with `pre-commit` locally. 

1. mypy and licensecheck are leveraging on the system level python, hence not properly using the internal venv. This removes the need of sourcing the virtual environment before committing
1. vale docs check doesn't work at second attempt because of the artifacts generated by the accessibility hook (stole from https://github.com/canonical/yarf/pull/43)

## Resolved issues

N/A

## Documentation

Removed unnecessary version requirement.

## Tests

Run locally `pre-commit run -a`.
And CI will do the rest.
