### PR TITLE
Add fetch depth 0 for accessibility check

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '00 19 * * *'
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read
@@ -12,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (main branch)
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@v5
         with:
           ref: main
           lfs: true
+          fetch-depth: 0
+
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies


### PR DESCRIPTION
## Description

Recently we add accessibility check to pre-commit, requires a non-shallow clone for the repo. This PR updates the TICS CI to have a non-shallow clone.

## Resolved issues

N/A

## Documentation


## Tests


