### PR TITLE
[Infra] configure prefix for dependency bots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+commit-message:
+  prefix: "[Infra] "

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "commitMessagePrefix": "[Infra] "
 }


### PR DESCRIPTION
<!--
Example Title: [BugFix] Fixed bugged behaviour of YARF load config

Pick one of the following:
- Infra: Your change only includes documentation, comments or github actions
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility

Signed commits are required.

The default merge method of this repository is Squash and Merge, please add a comment if Merge Commit is preferred.
-->

## Description

Bots are now failing CI because of the wrong PR title, this should address the issue.

Documentation:
1. https://docs.renovatebot.com/configuration-options/#commitmessageprefix
2. https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#commit-message--

## Resolved issues

N/A

## Documentation

N/A

## Tests

I can't think of any way to test it unfortunately.
