### PR TITLE
[BugFix] Update nesting level for commit-message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-commit-message:
-  prefix: "[Infra] "
+
+    commit-message:
+      prefix: "[Infra] "


### PR DESCRIPTION
## Description

Update Dependabot `commit-message` nesting level to under `updates`

## Resolved issues

https://github.com/canonical/yarf/pull/8/checks?check_run_id=50035276672

## Documentation

N/A

## Tests

