### PR TITLE
[BugFix] Change `asyncio_default_fixture_loop_scope` to function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ extend-exclude = [
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore=docs/ --ignore=hatch_build.py"
-asyncio_default_fixture_loop_scope = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "output_size",
     "start_suite",


### PR DESCRIPTION
## Description

This PR change the value of `asyncio_default_fixture_loop_scope` to function because auto becomes invalid.
`asyncio_default_fixture_loop_scope`  defines the lifetime of the default event loop fixture (event_loop) when we use pytest-asyncio.

## Resolved issues

Running tests
Example: https://github.com/canonical/yarf/actions/runs/17667503112/job/50215717883?pr=60

## Documentation



## Tests

See CI
