### PR TITLE
[Infra] replace 'tag' style actions version with the latest hash

### DIFF
--- a/.github/workflows/snap-evaluate-version.yaml
+++ b/.github/workflows/snap-evaluate-version.yaml
@@ -20,18 +20,18 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: gittools/actions/gitversion/setup@v4
+      - uses: gittools/actions/gitversion/setup@b82e662a7199df56ac962118e506d9efb9830f82
         with:
           versionSpec: '6.x'
 
       - name: Evaluate semantic version
         id: gv
-        uses: gittools/actions/gitversion/execute@v4
+        uses: gittools/actions/gitversion/execute@b82e662a7199df56ac962118e506d9efb9830f82
         with:
           configFilePath: GitVersion.yaml
 
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "${{ toJson(steps.gv.outputs) }}"
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
 
       - name: Normalize version to comply with PEP 440
         id: nv
@@ -55,7 +55,7 @@ jobs:
           echo "version=$VERSION_PEP440" >> "$GITHUB_OUTPUT"
 
       - name: Trigger snap build
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const version = "${{ steps.nv.outputs.version }}";

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -22,17 +22,17 @@ jobs:
   set-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           ref: ${{ inputs.commit_sha }}
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
 
       - name: Set version
         run: uv version "${{ inputs.version }}" --frozen
 
       - name: Upload updated project files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: updated-project-files
           path: |
@@ -47,7 +47,7 @@ jobs:
         ref: ${{ inputs.commit_sha }}
 
     - name: Download updated project files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
       with:
         name: updated-project-files
         path: .
@@ -73,7 +73,7 @@ jobs:
         ref: ${{ inputs.commit_sha }}
 
     - name: Download updated project files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
       with:
         name: updated-project-files
         path: .

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -59,7 +59,7 @@ jobs:
           mv ./coverage.xml ./coverage/cobertura.xml
 
       - name: TICS GitHub Action
-        uses: tiobe/tics-github-action@v3
+        uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7
         with:
           mode: qserver
           project: yarf

--- a/.github/workflows/yarf.yaml
+++ b/.github/workflows/yarf.yaml
@@ -73,7 +73,7 @@ jobs:
       run: |
         uv tool run tox
     - name: Upload Coverage Report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: coverage
         path: ./coverage.xml


### PR DESCRIPTION
## Description

Following [github guidelines](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) on using third party actions, this PR updates all the pinned tags to the latest digest.

Yes, we need to add `zizmor`.

## Resolved issues

Resolves

1. https://github.com/canonical/yarf/pull/63
2. https://github.com/canonical/yarf/pull/64
3. https://github.com/canonical/yarf/pull/65
4. https://github.com/canonical/yarf/pull/66

## Documentation

N/A

## Tests

CI will do.
