### PR TITLE
[BugFix] Modify dependency for gi

### DIFF
--- a/.github/workflows/yarf.yaml
+++ b/.github/workflows/yarf.yaml
@@ -112,7 +112,7 @@ jobs:
     - name: Install tutorial dependencies
       run: |
         sudo apt-get --yes --no-install-recommends install \
-          python3-gi \
+          libgirepository-2.0-dev \
           gir1.2-gtk-4.0 \
           libadwaita-1-dev \
           gir1.2-adw-1
@@ -130,7 +130,7 @@ jobs:
         # Wait for the compositor to start
         inotifywait --event create --include "^$XDG_RUNTIME_DIR/wayland-0\$" $XDG_RUNTIME_DIR
 
-        uv venv --python=/usr/bin/python3 --system-site-packages --project=$(pwd)/examples/yarf-example-simple-counter
+        uv sync --project=$(pwd)/examples/yarf-example-simple-counter
         dbus-run-session -- uv --project=$(pwd)/examples/yarf-example-simple-counter run simple-counter &
 
         uv run yarf --platform Mir examples/yarf-example-simple-counter/yarf_tests

--- a/docs/tutorial/getting_started.md
+++ b/docs/tutorial/getting_started.md
@@ -54,7 +54,7 @@ caption: Command for installing simple-counter dependencies.
 ---
 sudo apt update
 sudo apt install \
-    python3-gi \
+    libgirepository-2.0-dev \
     gir1.2-gtk-4.0 \
     libadwaita-1-dev \
     gir1.2-adw-1

--- a/examples/yarf-example-simple-counter/pyproject.toml
+++ b/examples/yarf-example-simple-counter/pyproject.toml
@@ -9,6 +9,9 @@ description = "A simple GUI counter"
 authors = [{ name = "Hou Nam Chiang", email = "douglas.chiang@canonical.com" }]
 readme = "README.md"
 requires-python = ">=3.12"
+dependencies = [
+    "pygobject"
+]
 
 [project.scripts]
 simple-counter = "simple_counter.main:main"

--- a/examples/yarf-example-simple-counter/uv.lock
+++ b/examples/yarf-example-simple-counter/uv.lock
@@ -3,6 +3,37 @@ revision = 2
 requires-python = ">=3.12"
 
 [[package]]
+name = "pycairo"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz", hash = "sha256:26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc", size = 662477, upload-time = "2025-04-14T20:11:08.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/d7/206d7945aac5c6c889e7fea4011410d1311455a1d8dfce66106d8d700b7f/pycairo-1.28.0-cp312-cp312-win32.whl", hash = "sha256:c00cfbb7f30eb7ca1d48886712932e2d91e8835a8496f4e423878296ceba573e", size = 750594, upload-time = "2025-04-14T20:10:53.72Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ba/259fc9a4d3afdad1e5b9db52b9d8a5df67f70dd787167185e8ec8a1af007/pycairo-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:d50d190f5033992b55050b9f337ee42a45c3568445d5e5d7987bab96c278d8a6", size = 841767, upload-time = "2025-04-14T20:10:56.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/08/aa0903612ea0e8686ad6af58d4fb9cbab8ee0b0831201cddf7abd578d045/pycairo-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:957e0340ee1c279d197d4f7cfa96f6d8b48e453eec711fca999748d752468ff4", size = 691687, upload-time = "2025-04-16T19:30:23.729Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/c3e5ed55781dfe1b31eb4a2482aeae707671f3d36b0ea53a1722f4a3dfe9/pycairo-1.28.0-cp313-cp313-win32.whl", hash = "sha256:d13352429d8a08a1cb3607767d23d2fb32e4c4f9faa642155383980ec1478c24", size = 750594, upload-time = "2025-04-14T20:10:59.284Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/1c/ebadd290748aff3b6bc35431114d41e7a42f40a4b988c2aaf2dfed5d8156/pycairo-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:082aef6b3a9dcc328fa648d38ed6b0a31c863e903ead57dd184b2e5f86790140", size = 841774, upload-time = "2025-04-14T20:11:01.79Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ce/a3f5f1946613cd8a4654322b878c59f273c6e9b01dfadadd3f609070e0b9/pycairo-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:026afd53b75291917a7412d9fe46dcfbaa0c028febd46ff1132d44a53ac2c8b6", size = 691675, upload-time = "2025-04-16T19:30:26.565Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1b/1f5da2b2e44b33a5b269ff28af710b0a7903001d9cf8a40d00fc944a5092/pycairo-1.28.0-cp314-cp314-win32.whl", hash = "sha256:d0ab30585f536101ad6f09052fc3895e2a437ba57531ea07223d0e076248025d", size = 766699, upload-time = "2025-07-24T06:36:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/91/1d5f18bd3ed469b1de8f83bfbf8bd67d23439f075151b66740fd35356190/pycairo-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:94f2ed204999ab95a0671a0fa948ffbb9f3d6fb8731fe787917f6d022d9c1c0f", size = 868725, upload-time = "2025-07-24T06:36:09.597Z" },
+]
+
+[[package]]
+name = "pygobject"
+version = "3.54.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycairo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/b2/24c2cda5b0cc76e687672738f5b388dcfc3a69d4b83584429dd9846a3341/pygobject-3.54.2.tar.gz", hash = "sha256:03cffeb49d8a1879b621d8f606ac904218019a0ae699b1cd3780a8ee611e696b", size = 1272228, upload-time = "2025-09-13T07:49:01.215Z" }
+
+[[package]]
 name = "simple-counter"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pygobject" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pygobject" }]


### PR DESCRIPTION
## Description

This PR adds `pygobject` and the apt package `libgirepository-2.0-dev` for `gi`.

## Resolved issues

The issue:
```
ModuleNotFoundError: No module named 'gi'
```

even we installed `python-gi` in `apt`, due to python version difference between `uv` managed and the system ones.

## Documentation


## Tests

Please visit quality CI
