### PR TITLE
[Infra] Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ We can install YARF along with the dependencies specified in
 `pyproject.toml` in the virtual environment using the command:
 
 ```shell
+uv --no-managed-python venv --system-site-packages
 uv sync
 uv pip install .[develop]
 ```


### PR DESCRIPTION
## Description

This PR updates the contributing guide with the additional command:
```
uv --no-managed-python venv --system-site-packages
```

because we have the installation of `python-tk` and `python-gi` can be installed into a system python version that is different to the one uv used.

## Resolved issues

https://github.com/canonical/yarf/pull/69

## Documentation


## Tests


