### PR TITLE
[Infra] Add commit SHA to the snap package it was built from.

### DIFF
--- a/.github/scripts/snap-evaluate-version/normalize-version.sh
+++ b/.github/scripts/snap-evaluate-version/normalize-version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+GITHUB_REF_NAME="$1"
+SEMVER="$2"
+INFORMATIONAL_VERSION="$3"
+
+echo "Normalizing version for PEP 440 compliance..."
+
+if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+  VERSION="$SEMVER"
+  echo "Using semVer for main branch: $VERSION"
+else
+  VERSION="$INFORMATIONAL_VERSION"
+  echo "Using informationalVersion for feature branch: $VERSION"
+fi
+
+VERSION_PEP440=$(uv tool run --with packaging python -c "from packaging.version import Version; print(Version('$VERSION'))")
+echo "Normalized PEP 440 version: $VERSION_PEP440"
+
+echo "version=$VERSION_PEP440" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/snap/add-commit-sha.sh
+++ b/.github/scripts/snap/add-commit-sha.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 COMMIT_SHA="$1"
 COMMIT_SHA_SHORT="$2"
-OUTPUT_FILE="yarf/_commit_sha.py"
+OUTPUT_FILE="yarf/metadata.py"
 
 echo "Adding commit SHA to snap..."
 cat > "$OUTPUT_FILE" << EOF

--- a/.github/scripts/snap/add-commit-sha.sh
+++ b/.github/scripts/snap/add-commit-sha.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+COMMIT_SHA="$1"
+COMMIT_SHA_SHORT="$2"
+OUTPUT_FILE="yarf/_commit_sha.py"
+
+echo "Adding commit SHA to snap..."
+cat > "$OUTPUT_FILE" << EOF
+COMMIT_SHA = "$COMMIT_SHA"
+COMMIT_SHA_SHORT = "$COMMIT_SHA_SHORT"
+EOF

--- a/.github/workflows/snap-evaluate-version.yaml
+++ b/.github/workflows/snap-evaluate-version.yaml
@@ -45,33 +45,25 @@ jobs:
       - name: Normalize version to comply with PEP 440
         id: nv
         run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
-            VERSION="${{ steps.gv.outputs.semVer }}"
-          else
-            VERSION="${{ steps.gv.outputs.informationalVersion }}"
-          fi
-          VERSION_PEP440=$(uv tool run --with packaging python -c "from packaging.version import Version; print(Version('$VERSION'))")
-          echo "Normalized PEP 440 version: $VERSION_PEP440"
-
-          echo "version=$VERSION_PEP440" >> "$GITHUB_OUTPUT"
+          .github/scripts/snap-evaluate-version/normalize-version.sh \
+            "${{ github.ref_name }}" \
+            "${{ steps.gv.outputs.semVer }}" \
+            "${{ steps.gv.outputs.informationalVersion }}"
 
       - name: Trigger snap build
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
-            const version = "${{ steps.nv.outputs.version }}";
-            const sha = "${{ steps.gv.outputs.sha }}";
-            const short_sha = "${{ steps.gv.outputs.shortSha }}";
             const response = await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: process.env.TARGET_WORKFLOW,
               ref: context.ref,
               inputs: {
-                version: version,
-                commit_sha: sha,
-                commit_short_sha: short_sha
+                version: "${{ steps.nv.outputs.version }}",
+                commit_sha: "${{ steps.gv.outputs.sha }}",
+                commit_short_sha: "${{ steps.gv.outputs.shortSha }}"
               }
             });
 
-            core.notice(`Triggered snap build for ${version} (${sha})`);
+            core.notice(`Triggered snap build for ${{ steps.nv.outputs.version }} (${{ steps.gv.outputs.sha }})`);

--- a/.github/workflows/snap-evaluate-version.yaml
+++ b/.github/workflows/snap-evaluate-version.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - commit-sha-in-snap
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -40,7 +40,7 @@ jobs:
           name: updated-project-files
           path: |
             pyproject.toml
-            yarf/_commit_sha.py
+            yarf/metadata.py
 
   build_and_publish_amd64:
     needs: [set-version]

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -31,12 +31,20 @@ jobs:
       - name: Set version
         run: uv version "${{ inputs.version }}" --frozen
 
+      - name: Add commit sha to the snap
+        run: |
+          cat > yarf/_commit_sha.py << EOF
+          COMMIT_SHA = "${{ inputs.commit_sha }}"
+          COMMIT_SHA_SHORT = "${{ inputs.commit_short_sha }}"
+          EOF
+
       - name: Upload updated project files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: updated-project-files
           path: |
             pyproject.toml
+            yarf/_commit_sha.py
 
   build_and_publish_amd64:
     needs: [set-version]
@@ -57,12 +65,12 @@ jobs:
       with:
         name: yarf-amd64
         path: ${{ steps.snapcraft.outputs.snap }}
-    - uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT }}
-      with:
-        snap: ${{ steps.snapcraft.outputs.snap }}
-        release: edge
+    # - uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
+    #   env:
+    #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT }}
+    #   with:
+    #     snap: ${{ steps.snapcraft.outputs.snap }}
+    #     release: edge
 
   build_and_publish_arm64:
     needs: [set-version]
@@ -83,9 +91,9 @@ jobs:
       with:
         name: yarf-arm64
         path: ${{ steps.snapcraft.outputs.snap }}
-    - uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT }}
-      with:
-        snap: ${{ steps.snapcraft.outputs.snap }}
-        release: edge
+    # - uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40
+    #   env:
+    #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT }}
+    #   with:
+    #     snap: ${{ steps.snapcraft.outputs.snap }}
+    #     release: edge

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -32,11 +32,7 @@ jobs:
         run: uv version "${{ inputs.version }}" --frozen
 
       - name: Add commit sha to the snap
-        run: |
-          cat > yarf/_commit_sha.py << EOF
-          COMMIT_SHA = "${{ inputs.commit_sha }}"
-          COMMIT_SHA_SHORT = "${{ inputs.commit_short_sha }}"
-          EOF
+        run: .github/scripts/snap/add-commit-sha.sh "${{ inputs.commit_sha }}" "${{ inputs.commit_short_sha }}"
 
       - name: Upload updated project files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
## Description
- The approach: before building snap package generate `metadata.py` with commit sha.
- `metadata.py` will be packed and will reside in:
  - `/lib/python3.12/site-packages/yarf` inside the snap package.
  - `/snap/yarf/current/lib/python3.12/site-packages/yarf` when snap is installed.
  - After installation of the yarf snap the value can be retrieved by:
```bash
PYTHONPATH=$(echo /snap/yarf/current/lib/**/site-packages) python3 -c "from yarf import metadata; print(metadata.COMMIT_SHA)"
```
- Bonus: move some shell cmds out from the workflow to the dedicated shell scripts.

## Resolved issues
N/A

## Documentation
N/A

## Tests
Manually install snap from the [build ](https://github.com/canonical/yarf/actions/runs/17999338880) artifacts and explore paths/scripts from the description.