### PR TITLE
[BugFix] Add interface hook for plugin example

### DIFF
--- a/docs/how-to/platform-plugins.md
+++ b/docs/how-to/platform-plugins.md
@@ -146,6 +146,11 @@ There are two ways to manage platform plugins in YARF:
    sudo snap connect snap-with-plugin:write-yarf-platform-plugins yarf:platform-plugins
    ```
 
+   ```{tip}
+   We recommend writing interface hooks for easy onboarding and removal of the plugin.
+   For details on how to write interface hooks, please visit [here](https://snapcraft.io/docs/interface-hooks).
+   ```
+
    After that, we will need to move `yarf_plugin_platform_A` to `$SNAP_COMMON/platform-to-plug`.
 
 A working example of a platform plugin can be found in `examples/yarf-example-plugin` of the YARF repository.

--- a/examples/yarf-example-plugin/snap/hooks/connect-plug-platform-plugins
+++ b/examples/yarf-example-plugin/snap/hooks/connect-plug-platform-plugins
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-# This configure file copies the example plugin to $SNAP_COMMON/platform_plugins/ when the snap is installed
+# This hook copies the example plugin to $SNAP_COMMON/platform_plugins/
+# when we run the `platform-plugins` connection.
+# For details on how this hook work, please visit:
+# https://snapcraft.io/docs/interface-hooks
 SRC="$SNAP/lib/python3.12/site-packages/yarf_plugin_example"
 DEST="$SNAP_COMMON/platform_plugins/yarf_plugin_example"
 

--- a/examples/yarf-example-plugin/snap/hooks/disconnect-plug-platform-plugins
+++ b/examples/yarf-example-plugin/snap/hooks/disconnect-plug-platform-plugins
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+DEST="$SNAP_COMMON/platform_plugins/yarf_plugin_example"
+
+rm -rf "$DEST"
+
+echo "Removed plugin from $DEST"


### PR DESCRIPTION
## Description

This PR adds interface hook for plugin example, which solves the issue that the content sharing interface does not share the contents that exists before the connection is made, so the plugin copied by the configure hook was not there.

## Resolved issues


## Documentation

added

## Tests

1. Build and install the sanp
2. Connect the plugin with YARF
3. `snap run yarf --help` should display the plugin `Example`
4. Disconnecting the interface should remove the plugin `Example`, try to verify that with `snap run yarf --help` again.
