### PR TITLE
[BugFix] Remove Robot Framework version pin in example plugin

### DIFF
--- a/examples/yarf-example-plugin/pyproject.toml
+++ b/examples/yarf-example-plugin/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "robotframework~=6.1.1",
+    "robotframework",
     # A YARF dependency is required here. E.g.: "yarf @ git+https://github.com/canonical/yarf.git@2.0.1".
     # However we are not doing this here because we determine YARF version dynamically.
 ]


### PR DESCRIPTION
## Description

This PR remove the version pin of Robot Framework in our example platform.

## Resolved issues

https://github.com/canonical/yarf/actions/runs/18041660273/job/51341951539?pr=8

## Documentation



## Tests


