### PR TITLE
[Infra] use a `WAYLAND_DISPLAY` less likely to clash

### DIFF
--- a/docs/tutorial/getting_started.md
+++ b/docs/tutorial/getting_started.md
@@ -55,7 +55,7 @@ Now, let's start the Mir server:
 caption: The command to start the mir-test-tools demo server with virtual 
   pointer.
 ---
-export WAYLAND_DISPLAY=wayland-0
+export WAYLAND_DISPLAY=wayland-99
 
 mir-test-tools.demo-server \
     --add-wayland-extensions zwlr_screencopy_manager_v1:zwlr_virtual_pointer_manager_v1 &


### PR DESCRIPTION
## Description
Avoid clashing on `WAYLAND_DISPLAY`.

## Resolved issues
```
ERROR: WAYLAND_DISPLAY is set, and already provided by a compositor. Mir will be unable to start!
```

## Documentation
:+1: 

## Tests
:+1: 