### PR TITLE
[New] Make RPA/recognition/ocr return actual confidence

### DIFF
--- a/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
+++ b/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
@@ -26,8 +26,8 @@ class TestRapidOCR:
 
     def test_read(self, mock_reader):
         reader_result = [
-            [[[0, 0], [0, 0], [0, 0], [0, 0]], "Hello", 0.9],
-            [[[0, 0], [0, 0], [0, 0], [0, 0]], "World", 0.8],
+            [[[0, 0], [0, 0], [0, 0], [0, 0]], "Hello", 90],
+            [[[0, 0], [0, 0], [0, 0], [0, 0]], "World", 80],
         ]
         mock_reader.reader.return_value = (reader_result, None)
         result = RapidOCRReader.read(mock_reader, None)
@@ -41,11 +41,16 @@ class TestRapidOCR:
 
     def test_find(self, mock_reader):
         mock_reader.reader.return_value = (
-            [[[[0, 0], [0, 0], [0, 0], [0, 0]], "Hello", 0.9]],
+            [[[[0, 0], [0, 0], [0, 0], [0, 0]], "Hello", 90]],
             None,
         )
         mock_reader.get_matches.return_value = [
-            {"text": "Hello", "region": Region(0, 0, 1, 1), "confidence": 100}
+            {
+                "text": "Hello",
+                "region": Region(0, 0, 1, 1),
+                "confidence": 90,
+                "similarity": 100,
+            }
         ]
         result = RapidOCRReader.find(mock_reader, None, "Hello")
 
@@ -53,7 +58,8 @@ class TestRapidOCR:
             {
                 "text": "Hello",
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "confidence": 90,
+                "similarity": 100,
             }
         ]
 
@@ -72,11 +78,16 @@ class TestRapidOCR:
     def test_find_in_region(self, mock_to_image, mock_reader):
         mock_to_image.return_value = MagicMock()
         mock_reader.reader.return_value = (
-            [[[[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 0.9]],
+            [[[[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 90]],
             None,
         )
         mock_reader.get_matches.return_value = [
-            {"text": "Hello", "region": Region(0, 0, 1, 1), "confidence": 100}
+            {
+                "text": "Hello",
+                "region": Region(0, 0, 1, 1),
+                "confidence": 90,
+                "similarity": 100,
+            }
         ]
         result = RapidOCRReader.find(
             mock_reader, None, "Hello", region=Region(0, 0, 1, 1)
@@ -86,50 +97,53 @@ class TestRapidOCR:
             {
                 "text": "Hello",
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "confidence": 90,
+                "similarity": 100,
             }
         ]
 
     def test_get_matches(self, mock_reader):
         items = [
             OCRResult(
-                Quad([[0, 0], [1, 0], [1, 1], [0, 1]]), "Hello World", 0.9
+                Quad([[0, 0], [1, 0], [1, 1], [0, 1]]), "Hello World", 90
             ),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, "Hello World", 0.8, 80, False
+            mock_reader, items, "Hello World", 80, 80, False
         )
 
         assert result == [
             {
                 "text": "Hello World",
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "confidence": 90,
+                "similarity": 100,
             }
         ]
 
     def test_get_matches_partial(self, mock_reader):
         items = [
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 0.9),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 90),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, "Hello", 0.8, 80, True
+            mock_reader, items, "Hello", 80, 80, True
         )
 
         assert result == [
             {
                 "text": "Hello World",
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "confidence": 90,
+                "similarity": 100,
             }
         ]
 
     def test_get_matches_no_matches(self, mock_reader):
         items = [
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 0.9),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 90),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, "Hello", 0.8, 90, False
+            mock_reader, items, "Hello", 80, 90, False
         )
 
         assert result == []
@@ -144,18 +158,19 @@ class TestRapidOCR:
     def test_substring_match(self, mock_reader, input_text, result_text):
         "Substrings match 100% to longer results"
         items = [
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Trash", 0.9),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 0.9),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to ...", 0.9),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Trash", 90),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 90),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to ...", 90),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, input_text, 0.8, 80, True
+            mock_reader, items, input_text, 80, 80, True
         )
         for text in result_text:
             assert {
                 "text": text,
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "confidence": 90,
+                "similarity": 100,
             } in result
 
     @pytest.mark.parametrize(
@@ -170,37 +185,38 @@ class TestRapidOCR:
         - "Move to Trash"  does not match     "Trash"        .
         """
         items = [
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Trash", 0.9),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 0.9),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to ...", 0.9),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Trash", 90),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 90),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to ...", 90),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, input_text, 0.8, 90, True
+            mock_reader, items, input_text, 90, 80, True
         )
         assert len(result) == 1
         assert result == [
             {
                 "text": result_text,
                 "region": Region(0, 0, 1, 1),
-                "confidence": 100,
+                "similarity": 100,
+                "confidence": 90,
             }
         ]
 
     def test_asimetric_long_match(self, mock_reader):
         items = [
             OCRResult(
-                [[0, 0], [1, 0], [1, 1], [0, 1]], "Trash a set of files", 0.9
+                [[0, 0], [1, 0], [1, 1], [0, 1]], "Trash a set of files", 90
             ),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 0.9),
-            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "!", 0.9),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Move to Trash", 90),
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "!", 90),
             OCRResult(
                 [[0, 0], [1, 0], [1, 1], [0, 1]],
                 "Move to Downloads",
-                0.9,
+                90,
             ),
         ]
         result = RapidOCRReader.get_matches(
-            mock_reader, items, "Move to Trash!", 0.8, 80, True
+            mock_reader, items, "Move to Trash!", 80, 80, True
         )
 
         assert result[0]["text"] == "Move to Trash"

--- a/yarf/vendor/RPA/recognition/ocr.py
+++ b/yarf/vendor/RPA/recognition/ocr.py
@@ -38,7 +38,7 @@ INSTALL_PROMPT = (
     "see library documentation for installation instructions"
 )
 
-DEFAULT_CONFIDENCE = 80.0
+DEFAULT_SIMILARITY_THRESHOLD = 80.0
 
 
 def read(
@@ -67,7 +67,7 @@ def read(
 def find(
     image: Union[Image.Image, Path],
     text: str,
-    confidence: float = DEFAULT_CONFIDENCE,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
     region: Optional[Region] = None,
     language: Optional[str] = None,
     configuration: Optional[str] = None
@@ -77,14 +77,16 @@ def find(
 
     :param image: Path to image or Image object
     :param text: Text to find in image
-    :param confidence: Minimum confidence for text similaritys
+    :param similarity_threshold: Minimum similarity percentage (0-100) for text
+     matching. If the similarity between the found text and the target text is
+     below this threshold, the match is discarded. The default value is 80.0.
     :param region: Limit the region of the screen where to look for the text
     :param language: 3-character ISO 639-2 language code of the text.
      This is passed directly to the pytesseract lib in the lang parameter.
      See https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html#using-one-language
     """  # noqa: E501
     image = to_image(image)
-    confidence = clamp(1, float(confidence), 100)
+    similarity_threshold = clamp(1, float(similarity_threshold), 100)
 
     text = str(text).strip()
     if not text:
@@ -107,7 +109,7 @@ def find(
         raise EnvironmentError(INSTALL_PROMPT) from err
 
     lines = _dict_lines(data)
-    matches = _match_lines(lines, text, confidence)
+    matches = _match_lines(lines, text, similarity_threshold)
 
     if region is not None:
         for match in matches:
@@ -144,9 +146,9 @@ def _iter_rows(data: Dict) -> Generator:
     return (dict(zip(data.keys(), values)) for values in zip(*data.values()))
 
 
-def _match_lines(lines: List[Dict], text: str, confidence: float) -> List[Dict]:
+def _match_lines(lines: List[Dict], text: str, similarity_threshold: float) -> List[Dict]:
     """Find best matches between lines of text and target text,
-    and return resulting bounding boxes and confidences.
+    and return resulting bounding boxes and similarities.
 
     A line of N words will be matched to the given text in all 1 to N
     length sections, in every sequential position.
@@ -161,21 +163,22 @@ def _match_lines(lines: List[Dict], text: str, confidence: float) -> List[Dict]:
                 regions = [word["region"] for word in words]
 
                 sentence = " ".join(word["text"] for word in words)
-                ratio = SequenceMatcher(None, sentence, text).ratio() * 100.0
+                similarity = SequenceMatcher(None, sentence, text).ratio() * 100.0
 
-                if ratio < confidence:
+                if similarity < similarity_threshold:
                     continue
 
-                if match and match["confidence"] >= ratio:
+                if match and match["similarity"] >= similarity:
+                    # We already have a better match
                     continue
 
                 match = {
                     "text": sentence,
                     "region": Region.merge(regions),
-                    "confidence": ratio,
+                    "similarity": similarity,
                 }
 
         if match:
             matches.append(match)
 
-    return sorted(matches, key=lambda match: match["confidence"], reverse=True)
+    return sorted(matches, key=lambda match: match["similarity"], reverse=True)

--- a/yarf/vendor/RPA/recognition/ocr.py
+++ b/yarf/vendor/RPA/recognition/ocr.py
@@ -134,8 +134,7 @@ def _dict_lines(data: Dict) -> List:
             word["left"], word["top"], word["width"], word["height"]
         )
 
-        # NOTE: Currently ignoring confidence in tesseract results
-        lines[key].append({"text": word["text"], "region": region})
+        lines[key].append({"text": word["text"], "region": region, "confidence": word["conf"]})
         assert len(lines[key]) == word["word_num"]
 
     return list(lines.values())
@@ -172,10 +171,14 @@ def _match_lines(lines: List[Dict], text: str, similarity_threshold: float) -> L
                     # We already have a better match
                     continue
 
+                # Use the lowest confidence among the words in the match
+                confidence = min(word["confidence"] for word in words if word["confidence"] != -1)
+
                 match = {
                     "text": sentence,
                     "region": Region.merge(regions),
                     "similarity": similarity,
+                    "confidence": confidence,
                 }
 
         if match:


### PR DESCRIPTION
## Description

The `yarf/vendor/RPA/recognition/ocr.py` module only returned similarity but tesseract does actually also return confidence values, we just have to use it.

## Tests

The module doesn't have any tests as far as I can see and I didn't add any.

> [!important]
> This is based on https://github.com/canonical/yarf/pull/138, please review that PR first.