### PR TITLE
[New] LLM corrupted image detection

### DIFF
--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -12,7 +12,7 @@
 <p>Detect if an image is corrupted.</p>
 <p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
-<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
+<p>Raises: RuntimeError: If the screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
 
 ### Return
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -7,24 +7,10 @@
 
 ## Keywords
 
-### Configure Llm Client
-
-<p>Configure the LLM client with the given parameters.</p>
-<p>Args: **kwargs: Configuration parameters for the LLM client.</p>
-<p>Raises: TypeError: If unknown parameters are provided. ValueError: If parameter values are of incorrect type.</p>
-
-#### Positional and named arguments
-
-| Name   | Type | Default Value | Kind      | Required |
-| ------ | ---- | ------------- | --------- | -------- |
-| kwargs | Any  |               | VAR_NAMED | No       |
-
-<hr style="border:1px solid grey">
-
-### Detect Corrupted Image
+### Check For Visual Corruption
 
 <p>Detect if an image is corrupted.</p>
-<p>Args: image: The image to check (PIL Image or path). custom_prompt: Optional custom prompt to guide the LLM.</p>
+<p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted, a description, and the number of votes.</p>
 <p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.</p>
 
@@ -38,6 +24,20 @@
 | ------------- | ---- | ------------- | ------------------- | -------- |
 | image         | None | None          | POSITIONAL_OR_NAMED | No       |
 | custom_prompt | None | None          | POSITIONAL_OR_NAMED | No       |
+
+<hr style="border:1px solid grey">
+
+### Configure Llm Client
+
+<p>Configure the LLM client with the given parameters.</p>
+<p>Args: **kwargs: Configuration parameters for the LLM client.</p>
+<p>Raises: TypeError: If unknown parameters are provided. ValueError: If parameter values are of incorrect type.</p>
+
+#### Positional and named arguments
+
+| Name   | Type | Default Value | Kind      | Required |
+| ------ | ---- | ------------- | --------- | -------- |
+| kwargs | Any  |               | VAR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -21,6 +21,26 @@
 
 <hr style="border:1px solid grey">
 
+### Detect Corrupted Image
+
+<p>Detect if an image is corrupted.</p>
+<p>Args: image: The image to check (PIL Image or path). custom_prompt: Optional custom prompt to guide the LLM.</p>
+<p>Returns: A dict containing the LLM's assessment of whether the image is corrupted, a description, and the number of votes.</p>
+<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.</p>
+
+### Return
+
+{'name': 'dict', 'typedoc': 'dictionary', 'nested': \[{'name': 'str', 'typedoc': 'string', 'nested': [], 'union': False}, {'name': 'Any', 'typedoc': 'Any', 'nested': [], 'union': False}\], 'union': False}
+
+#### Positional and named arguments
+
+| Name          | Type | Default Value | Kind                | Required |
+| ------------- | ---- | ------------- | ------------------- | -------- |
+| image         | None | None          | POSITIONAL_OR_NAMED | No       |
+| custom_prompt | None | None          | POSITIONAL_OR_NAMED | No       |
+
+<hr style="border:1px solid grey">
+
 ### Prompt Llm
 
 <p>Send a prompt (text-only or text+image) to the LLM and get the response.</p>

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -11,7 +11,7 @@
 
 <p>Detect if an image is corrupted.</p>
 <p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
-<p>Returns: A dict containing the LLM's assessment of whether the image is corrupted, a description, and the number of votes.</p>
+<p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
 <p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.</p>
 
 ### Return

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -12,7 +12,7 @@
 <p>Detect if an image is corrupted.</p>
 <p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
-<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.</p>
+<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid. YARFValidationError: If the image is assessed as corrupted by the LLM.</p>
 
 ### Return
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -12,7 +12,7 @@
 <p>Detect if an image is corrupted.</p>
 <p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
-<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid. YARFValidationError: If the image is assessed as corrupted by the LLM.</p>
+<p>Raises: ValueError: If the screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
 
 ### Return
 

--- a/yarf/errors/yarf_errors.py
+++ b/yarf/errors/yarf_errors.py
@@ -34,7 +34,7 @@ class YARFConnectionError(YARFError):
 
 class VQAValidationError(Exception):
     """
-    Raised when validation fails.
+    Raised when VQA-driven validation fails.
     """
 
     pass

--- a/yarf/errors/yarf_errors.py
+++ b/yarf/errors/yarf_errors.py
@@ -30,3 +30,11 @@ class YARFConnectionError(YARFError):
     """
 
     exit_code: YARFExitCode = YARFExitCode.CONNECTION_ERROR
+
+
+class YARFValidationError(Exception):
+    """
+    Raised when validation fails.
+    """
+
+    pass

--- a/yarf/errors/yarf_errors.py
+++ b/yarf/errors/yarf_errors.py
@@ -32,7 +32,7 @@ class YARFConnectionError(YARFError):
     exit_code: YARFExitCode = YARFExitCode.CONNECTION_ERROR
 
 
-class YARFValidationError(Exception):
+class VQAValidationError(Exception):
     """
     Raised when validation fails.
     """

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -3,12 +3,14 @@ This module provides the Robot Framework library for interacting with an LLM
 server using OpenAPI.
 """
 
+import json
 from typing import Any
 
 import requests
 from PIL import Image
 from robot.api import logger
 from robot.api.deco import keyword, library
+from robot.libraries.BuiltIn import BuiltIn
 
 from yarf.lib.images.utils import to_base64
 from yarf.vendor.RPA.recognition.utils import to_image
@@ -137,3 +139,85 @@ class LlmClient:
 
         b64 = to_base64(image)
         return f"data:image/png;base64,{b64}"
+
+    def _get_lib_instance(self, lib_name: str) -> Any:
+        """
+        Helper function to get an instance of a library imported in Robot
+        Framework.
+
+        Args:
+            lib_name: The name of the library to get an instance of.
+
+        Returns:
+            An instance of the specified library.
+        """
+        return BuiltIn().get_library_instance(lib_name)
+
+    @keyword
+    async def detect_corrupted_image(
+        self,
+        image: Image.Image | None = None,
+        custom_prompt: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Detect if an image is corrupted.
+
+        Args:
+            image: The image to check (PIL Image or path).
+            custom_prompt: Optional custom prompt to guide the LLM.
+
+        Returns:
+            A dict containing the LLM's assessment of whether the image is
+            corrupted, a description, and the number of votes.
+
+        Raises:
+            ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.
+        """
+        if image is None:
+            platform_video_input = self._get_lib_instance("VideoInput")
+            if (image := await platform_video_input.grab_screenshot()) is None:
+                raise ValueError("Failed to grab screenshot.")
+
+        result = self.prompt_llm(
+            prompt=custom_prompt or "Detect if the image is corrupted.",
+            image=image,
+            system_prompt="""
+            You are a helpful assistant that can understand images and texts.
+            You have to assess if the provided image is corrupted or not.
+            This will probably be shown as noise in some parts of the image.
+            Output your answer in dict format with a short description (on 1 line)
+            and the number of votes.
+            Example: {"corrupted": true, "description": "...", "votes": 13}.
+            """,
+        )
+
+        # Use LLM to verify the response format and parse it as JSON
+        verification_prompt = f"""
+        Verify if the following response is in the correct format
+        (a dict with keys 'corrupted', 'description', and 'votes')
+        and can be parsed as JSON.
+        If it is correct, return the original response.
+        If it is incorrect, return False.
+        Response to verify: {result}
+        """
+
+        verified = self.prompt_llm(
+            prompt=verification_prompt,
+            system_prompt=(
+                "You are a JSON validator. Return only the valid"
+                " JSON dict or the word False. No extra text."
+            ),
+        )
+
+        if verified.strip().lower() == "false":
+            raise ValueError(
+                f"LLM returned an invalid response format: {result}"
+            )
+
+        try:
+            return json.loads(verified)
+
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"Failed to parse verified LLM response as JSON: {verified}"
+            )

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -189,9 +189,11 @@ class LlmClient:
             You are a helpful assistant that can understand images and texts.
             You have to assess if the provided image is corrupted or not.
             This will probably be shown as noise in some parts of the image.
-            Output your answer in dict format with a short description (on 1 line)
-            and the confidence score. Return JSON only.
-            Example: {"corrupted": true, "description": "..."}.
+            Output your answer in pure JSON format with the followings only:
+            1. corrupted: a boolean indicating if the image is corrupted
+            2. description: a short description (on 1 line)
+            Example output: {"corrupted": true, "description": "..."}.
+            Do not add markdown syntax or any other text.
             """,
         )
 

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -202,7 +202,7 @@ class LlmClient:
             "description": str,
         }
         parsed, error_messages = self._verify_llm_json_response(
-            result, set(required_keys.keys())
+            result, required_keys
         )
         if len(error_messages) > 0:
             result = await asyncio.to_thread(
@@ -219,7 +219,7 @@ class LlmClient:
                 """,
             )
             parsed, errors = self._verify_llm_json_response(
-                result, set(required_keys.keys())
+                result, required_keys
             )
             if errors:
                 raise RuntimeError("Failing to get a valid response from LLM")
@@ -234,7 +234,7 @@ class LlmClient:
     def _verify_llm_json_response(
         self,
         result: str,
-        required_keys: set[str],
+        required_keys: dict[str, type],
     ) -> tuple[dict[str, Any], str]:
         json_start = result.find("{")
         json_end = result.rfind("}")
@@ -253,19 +253,21 @@ class LlmClient:
             ) from exc
 
         error_messages = ""
-        missing_keys = required_keys - parsed.keys()
+        missing_keys = required_keys.keys() - parsed.keys()
         if missing_keys:
             error_messages += (
                 "LLM returned an invalid response format; missing keys: "
                 f"{sorted(missing_keys)}. Response: {parsed}"
             )
 
-        for key, expected in parsed.items():
-            if not isinstance(parsed[key], expected):
+        for key, value in parsed.items():
+            if key in required_keys and not isinstance(
+                value, required_keys[key]
+            ):
                 error_messages += (
                     f"LLM returned an invalid type for '{key}'; "
-                    f"expected {expected.__name__}, "
-                    f"got {type(parsed[key]).__name__}."
+                    f"expected {required_keys[key].__name__}, "
+                    f"got {type(value).__name__}."
                 )
 
         if error_messages:

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -188,7 +188,7 @@ class LlmClient:
             You have to assess if the provided image is corrupted or not.
             This will probably be shown as noise in some parts of the image.
             Output your answer in dict format with a short description (on 1 line)
-            and the number of votes.
+            and the confidence score. Return JSON only.
             Example: {"corrupted": true, "description": "...", "votes": 13}.
             """,
         )
@@ -213,24 +213,17 @@ class LlmClient:
                 f"{sorted(missing_keys)}. Response: {parsed}"
             )
 
-        if not isinstance(parsed["corrupted"], bool):
-            raise ValueError(
-                "LLM returned an invalid type for 'corrupted'; "
-                f"expected bool, got {type(parsed['corrupted']).__name__}."
-            )
-
-        if not isinstance(parsed["description"], str):
-            raise ValueError(
-                "LLM returned an invalid type for 'description'; "
-                f"expected str, got {type(parsed['description']).__name__}."
-            )
-
-        if not isinstance(parsed["votes"], int) or isinstance(
-            parsed["votes"], bool
-        ):
-            raise ValueError(
-                "LLM returned an invalid type for 'votes'; "
-                f"expected int, got {type(parsed['votes']).__name__}."
-            )
+        expected_types = {
+            "corrupted": bool,
+            "description": str,
+            "votes": int,
+        }
+        for key, expected in expected_types.items():
+            if not isinstance(parsed[key], expected):
+                raise ValueError(
+                    f"LLM returned an invalid type for '{key}'; "
+                    f"expected {expected.__name__}, "
+                    f"got {type(parsed[key]).__name__}."
+                )
 
         return parsed

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -13,7 +13,7 @@ from robot.api import logger
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
-from yarf.errors.yarf_errors import YARFValidationError
+from yarf.errors.yarf_errors import VQAValidationError
 from yarf.lib.images.utils import to_base64
 from yarf.vendor.RPA.recognition.utils import to_image
 
@@ -174,7 +174,7 @@ class LlmClient:
 
         Raises:
             ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.
-            YARFValidationError: If the image is assessed as corrupted by the LLM.
+            VQAValidationError: If the image is assessed as corrupted by the LLM.
         """
         if image is None:
             platform_video_input = self._get_lib_instance("VideoInput")
@@ -221,7 +221,7 @@ class LlmClient:
             )
 
         if parsed["corrupted"]:
-            raise YARFValidationError(
+            raise VQAValidationError(
                 f"Image is corrupted: {parsed['description']}"
             )
 

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -3,6 +3,7 @@ This module provides the Robot Framework library for interacting with an LLM
 server using OpenAPI.
 """
 
+import asyncio
 import json
 from typing import Any
 
@@ -178,7 +179,8 @@ class LlmClient:
             if (image := await platform_video_input.grab_screenshot()) is None:
                 raise ValueError("Failed to grab screenshot.")
 
-        result = self.prompt_llm(
+        result = await asyncio.to_thread(
+            self.prompt_llm,
             prompt=custom_prompt or "Detect if the image is corrupted.",
             image=image,
             system_prompt="""
@@ -201,7 +203,8 @@ class LlmClient:
         Response to verify: {result}
         """
 
-        verified = self.prompt_llm(
+        verified = await asyncio.to_thread(
+            self.prompt_llm,
             prompt=verification_prompt,
             system_prompt=(
                 "You are a JSON validator. Return only the valid"

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -250,4 +250,5 @@ class LlmClient:
                     f"got {type(parsed[key]).__name__}."
                 )
 
+        logger.warn(f"LLM response validation errors: {error_messages}")
         return parsed, error_messages

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -235,8 +235,15 @@ class LlmClient:
         required_keys: set[str],
         expected_types: dict[str, type],
     ) -> tuple[dict[str, Any], str]:
+        json_start = result.find("{")
+        json_end = result.rfind("}") + 1
+        if json_start == -1 or json_end == -1:
+            raise RuntimeError(
+                f"LLM response does not contain valid JSON: {result}"
+            )
+
         try:
-            parsed = json.loads(result)
+            parsed = json.loads(result[json_start:json_end])
         except json.JSONDecodeError as exc:
             raise RuntimeError(
                 f"Failed to parse LLM response as JSON: {result}"

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -218,9 +218,11 @@ class LlmClient:
                 Example: {"corrupted": true, "description": "..."}.
                 """,
             )
-            parsed, _ = self._verify_llm_json_response(
+            parsed, errors = self._verify_llm_json_response(
                 result, set(required_keys.keys()), required_keys
             )
+            if errors:
+                raise RuntimeError("Failing to get a valid response from LLM")
 
         if parsed["corrupted"]:
             raise VQAValidationError(
@@ -265,5 +267,6 @@ class LlmClient:
                     f"got {type(parsed[key]).__name__}."
                 )
 
-        logger.warn(f"LLM response validation errors: {error_messages}")
+        if error_messages:
+            logger.warn(f"LLM response validation errors: {error_messages}")
         return parsed, error_messages

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -169,7 +169,7 @@ class LlmClient:
 
         Returns:
             A dict containing the LLM's assessment of whether the image is
-            corrupted, a description, and the number of votes.
+            corrupted and a description.
 
         Raises:
             ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.
@@ -198,7 +198,7 @@ class LlmClient:
             "description": str,
         }
         parsed, error_messages = self._verify_llm_json_response(
-            result, required_keys, expected_types
+            result, set(required_keys.keys()), required_keys
         )
         if len(error_messages) > 0:
             result = await asyncio.to_thread(
@@ -215,7 +215,7 @@ class LlmClient:
                 """,
             )
             parsed, _ = self._verify_llm_json_response(
-                result, required_keys, expected_types
+                result, set(required_keys.keys()), required_keys
             )
 
         return parsed

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -155,7 +155,7 @@ class LlmClient:
         return BuiltIn().get_library_instance(lib_name)
 
     @keyword
-    async def detect_corrupted_image(
+    async def check_for_visual_corruption(
         self,
         image: Image.Image | str | None = None,
         custom_prompt: str | None = None,
@@ -164,7 +164,7 @@ class LlmClient:
         Detect if an image is corrupted.
 
         Args:
-            image: The image to check (PIL Image or path).
+            image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed.
             custom_prompt: Optional custom prompt to guide the LLM.
 
         Returns:
@@ -189,10 +189,44 @@ class LlmClient:
             This will probably be shown as noise in some parts of the image.
             Output your answer in dict format with a short description (on 1 line)
             and the confidence score. Return JSON only.
-            Example: {"corrupted": true, "description": "...", "votes": 13}.
+            Example: {"corrupted": true, "description": "..."}.
             """,
         )
 
+        required_keys = {"corrupted", "description"}
+        expected_types = {
+            "corrupted": bool,
+            "description": str,
+        }
+        parsed, error_messages = self._verify_llm_json_response(
+            result, required_keys, expected_types
+        )
+        if len(error_messages) > 0:
+            result = await asyncio.to_thread(
+                self.prompt_llm,
+                prompt=f"""
+                Please correct the previous response and output the correct JSON.
+                Previous response: {result}
+                Error details: {error_messages}
+                """,
+                system_prompt="""
+                You are a helpful assistant that can understand error outputs.
+                Output your answer in JSON format only.
+                Example: {"corrupted": true, "description": "..."}.
+                """,
+            )
+            parsed, _ = self._verify_llm_json_response(
+                result, required_keys, expected_types
+            )
+
+        return parsed
+
+    def _verify_llm_json_response(
+        self,
+        result: str,
+        required_keys: set[str],
+        expected_types: dict[str, type],
+    ) -> tuple[dict[str, Any], str]:
         try:
             parsed = json.loads(result)
         except json.JSONDecodeError as exc:
@@ -200,30 +234,20 @@ class LlmClient:
                 f"Failed to parse LLM response as JSON: {result}"
             ) from exc
 
-        if not isinstance(parsed, dict):
-            raise ValueError(
-                f"LLM returned a non-dict JSON response: {parsed}"
-            )
-
-        required_keys = {"corrupted", "description", "votes"}
+        error_messages = ""
         missing_keys = required_keys - parsed.keys()
         if missing_keys:
-            raise ValueError(
+            error_messages += (
                 "LLM returned an invalid response format; missing keys: "
                 f"{sorted(missing_keys)}. Response: {parsed}"
             )
 
-        expected_types = {
-            "corrupted": bool,
-            "description": str,
-            "votes": int,
-        }
         for key, expected in expected_types.items():
             if not isinstance(parsed[key], expected):
-                raise ValueError(
+                error_messages += (
                     f"LLM returned an invalid type for '{key}'; "
                     f"expected {expected.__name__}, "
                     f"got {type(parsed[key]).__name__}."
                 )
 
-        return parsed
+        return parsed, error_messages

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -193,8 +193,7 @@ class LlmClient:
             """,
         )
 
-        required_keys = {"corrupted", "description"}
-        expected_types = {
+        required_keys = {
             "corrupted": bool,
             "description": str,
         }

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -225,6 +225,9 @@ class LlmClient:
                 raise RuntimeError("Failing to get a valid response from LLM")
 
         if parsed["corrupted"]:
+            log_image(
+                image, "Corrupted image detected: " + parsed["description"]
+            )
             raise VQAValidationError(
                 f"Image is corrupted: {parsed['description']}"
             )

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -15,6 +15,7 @@ from robot.libraries.BuiltIn import BuiltIn
 
 from yarf.errors.yarf_errors import VQAValidationError
 from yarf.lib.images.utils import to_base64
+from yarf.rf_libraries.libraries.image.utils import log_image
 from yarf.vendor.RPA.recognition.utils import to_image
 
 

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -157,7 +157,7 @@ class LlmClient:
     @keyword
     async def detect_corrupted_image(
         self,
-        image: Image.Image | None = None,
+        image: Image.Image | str | None = None,
         custom_prompt: str | None = None,
     ) -> dict[str, Any]:
         """
@@ -193,34 +193,44 @@ class LlmClient:
             """,
         )
 
-        # Use LLM to verify the response format and parse it as JSON
-        verification_prompt = f"""
-        Verify if the following response is in the correct format
-        (a dict with keys 'corrupted', 'description', and 'votes')
-        and can be parsed as JSON.
-        If it is correct, return the original response.
-        If it is incorrect, return False.
-        Response to verify: {result}
-        """
-
-        verified = await asyncio.to_thread(
-            self.prompt_llm,
-            prompt=verification_prompt,
-            system_prompt=(
-                "You are a JSON validator. Return only the valid"
-                " JSON dict or the word False. No extra text."
-            ),
-        )
-
-        if verified.strip().lower() == "false":
-            raise ValueError(
-                f"LLM returned an invalid response format: {result}"
-            )
-
         try:
-            return json.loads(verified)
-
-        except json.JSONDecodeError:
+            parsed = json.loads(result)
+        except json.JSONDecodeError as exc:
             raise ValueError(
-                f"Failed to parse verified LLM response as JSON: {verified}"
+                f"Failed to parse LLM response as JSON: {result}"
+            ) from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"LLM returned a non-dict JSON response: {parsed}"
             )
+
+        required_keys = {"corrupted", "description", "votes"}
+        missing_keys = required_keys - parsed.keys()
+        if missing_keys:
+            raise ValueError(
+                "LLM returned an invalid response format; missing keys: "
+                f"{sorted(missing_keys)}. Response: {parsed}"
+            )
+
+        if not isinstance(parsed["corrupted"], bool):
+            raise ValueError(
+                "LLM returned an invalid type for 'corrupted'; "
+                f"expected bool, got {type(parsed['corrupted']).__name__}."
+            )
+
+        if not isinstance(parsed["description"], str):
+            raise ValueError(
+                "LLM returned an invalid type for 'description'; "
+                f"expected str, got {type(parsed['description']).__name__}."
+            )
+
+        if not isinstance(parsed["votes"], int) or isinstance(
+            parsed["votes"], bool
+        ):
+            raise ValueError(
+                "LLM returned an invalid type for 'votes'; "
+                f"expected int, got {type(parsed['votes']).__name__}."
+            )
+
+        return parsed

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -202,7 +202,7 @@ class LlmClient:
             "description": str,
         }
         parsed, error_messages = self._verify_llm_json_response(
-            result, set(required_keys.keys()), required_keys
+            result, set(required_keys.keys())
         )
         if len(error_messages) > 0:
             result = await asyncio.to_thread(
@@ -219,7 +219,7 @@ class LlmClient:
                 """,
             )
             parsed, errors = self._verify_llm_json_response(
-                result, set(required_keys.keys()), required_keys
+                result, set(required_keys.keys())
             )
             if errors:
                 raise RuntimeError("Failing to get a valid response from LLM")
@@ -235,7 +235,6 @@ class LlmClient:
         self,
         result: str,
         required_keys: set[str],
-        expected_types: dict[str, type],
     ) -> tuple[dict[str, Any], str]:
         json_start = result.find("{")
         json_end = result.rfind("}")
@@ -245,7 +244,9 @@ class LlmClient:
             )
 
         try:
-            parsed = json.loads(result[json_start:json_end+1])
+            parsed: dict[str, Any] = json.loads(
+                result[json_start : json_end + 1]
+            )
         except json.JSONDecodeError as exc:
             raise RuntimeError(
                 f"Failed to parse LLM response as JSON: {result}"
@@ -259,7 +260,7 @@ class LlmClient:
                 f"{sorted(missing_keys)}. Response: {parsed}"
             )
 
-        for key, expected in expected_types.items():
+        for key, expected in parsed.items():
             if not isinstance(parsed[key], expected):
                 error_messages += (
                     f"LLM returned an invalid type for '{key}'; "

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -13,6 +13,7 @@ from robot.api import logger
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
+from yarf.errors.yarf_errors import YARFValidationError
 from yarf.lib.images.utils import to_base64
 from yarf.vendor.RPA.recognition.utils import to_image
 
@@ -173,6 +174,7 @@ class LlmClient:
 
         Raises:
             ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.
+            YARFValidationError: If the image is assessed as corrupted by the LLM.
         """
         if image is None:
             platform_video_input = self._get_lib_instance("VideoInput")
@@ -216,6 +218,11 @@ class LlmClient:
             )
             parsed, _ = self._verify_llm_json_response(
                 result, set(required_keys.keys()), required_keys
+            )
+
+        if parsed["corrupted"]:
+            raise YARFValidationError(
+                f"Image is corrupted: {parsed['description']}"
             )
 
         return parsed

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -173,13 +173,13 @@ class LlmClient:
             corrupted and a description.
 
         Raises:
-            ValueError: If the screenshot could not be grabbed or if the LLM response is invalid.
+            RuntimeError: If the screenshot could not be grabbed or if the LLM response is invalid.
             VQAValidationError: If the image is assessed as corrupted by the LLM.
         """
         if image is None:
             platform_video_input = self._get_lib_instance("VideoInput")
             if (image := await platform_video_input.grab_screenshot()) is None:
-                raise ValueError("Failed to grab screenshot.")
+                raise RuntimeError("Failed to grab screenshot.")
 
         result = await asyncio.to_thread(
             self.prompt_llm,

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -236,14 +236,14 @@ class LlmClient:
         expected_types: dict[str, type],
     ) -> tuple[dict[str, Any], str]:
         json_start = result.find("{")
-        json_end = result.rfind("}") + 1
+        json_end = result.rfind("}")
         if json_start == -1 or json_end == -1:
             raise RuntimeError(
                 f"LLM response does not contain valid JSON: {result}"
             )
 
         try:
-            parsed = json.loads(result[json_start:json_end])
+            parsed = json.loads(result[json_start:json_end+1])
         except json.JSONDecodeError as exc:
             raise RuntimeError(
                 f"Failed to parse LLM response as JSON: {result}"

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -196,7 +196,7 @@ class LlmClient:
         try:
             parsed = json.loads(result)
         except json.JSONDecodeError as exc:
-            raise ValueError(
+            raise RuntimeError(
                 f"Failed to parse LLM response as JSON: {result}"
             ) from exc
 

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -280,7 +280,7 @@ class TestLlmClient:
                 "_get_lib_instance",
                 return_value=mock_video,
             ),
-            pytest.raises(ValueError, match="Failed to grab screenshot"),
+            pytest.raises(RuntimeError, match="Failed to grab screenshot"),
         ):
             await client.check_for_visual_corruption()
 

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -178,7 +178,6 @@ class TestLlmClient:
         {
             "corrupted": True,
             "description": "noise in top-left corner",
-            "votes": 7,
         }
     )
 
@@ -192,11 +191,12 @@ class TestLlmClient:
             ".asyncio.to_thread",
             return_value=self.VALID_RESPONSE,
         ):
-            result = await client.detect_corrupted_image(image=image)
+            result = await client.check_for_visual_corruption(
+                image=image,
+            )
 
         assert result["corrupted"] is True
         assert result["description"] == "noise in top-left corner"
-        assert result["votes"] == 7
 
     @pytest.mark.asyncio
     async def test_custom_prompt(self, mock_post):
@@ -208,7 +208,7 @@ class TestLlmClient:
             ".asyncio.to_thread",
             return_value=self.VALID_RESPONSE,
         ) as mock_thread:
-            await client.detect_corrupted_image(
+            await client.check_for_visual_corruption(
                 image=image, custom_prompt="Is this broken?"
             )
 
@@ -235,7 +235,7 @@ class TestLlmClient:
                 return_value=self.VALID_RESPONSE,
             ),
         ):
-            result = await client.detect_corrupted_image()
+            result = await client.check_for_visual_corruption()
 
         assert result["corrupted"] is True
         mock_video.grab_screenshot.assert_awaited_once()
@@ -255,7 +255,7 @@ class TestLlmClient:
             ),
             pytest.raises(ValueError, match="Failed to grab screenshot"),
         ):
-            await client.detect_corrupted_image()
+            await client.check_for_visual_corruption()
 
     @pytest.mark.asyncio
     async def test_raises_on_invalid_json(self, mock_post):
@@ -268,70 +268,92 @@ class TestLlmClient:
                 ".asyncio.to_thread",
                 return_value="not json at all",
             ),
-            pytest.raises(ValueError, match="Failed to parse LLM response"),
+            pytest.raises(RuntimeError, match="Failed to parse LLM response"),
         ):
-            await client.detect_corrupted_image(image=image)
+            await client.check_for_visual_corruption(image=image)
 
     @pytest.mark.asyncio
-    async def test_raises_on_non_dict_json(self, mock_post):
+    async def test_retries_on_wrong_type(self, mock_post):
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
+        bad = json.dumps({"corrupted": "yes", "description": "ok"})
 
-        with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value=json.dumps([1, 2, 3]),
-            ),
-            pytest.raises(ValueError, match="non-dict JSON response"),
-        ):
-            await client.detect_corrupted_image(image=image)
+        with patch(
+            "yarf.rf_libraries.libraries.llm_client.LlmClient"
+            ".asyncio.to_thread",
+            side_effect=[bad, self.VALID_RESPONSE],
+        ) as mock_thread:
+            result = await client.check_for_visual_corruption(
+                image=image,
+            )
 
-    @pytest.mark.asyncio
-    async def test_raises_on_missing_keys(self, mock_post):
-        client = LlmClient()
-        image = Image.new("RGB", (10, 10))
-
-        with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value=json.dumps({"corrupted": True}),
-            ),
-            pytest.raises(ValueError, match="missing keys"),
-        ):
-            await client.detect_corrupted_image(image=image)
+        assert mock_thread.call_count == 2
+        assert result["corrupted"] is True
+        assert result["description"] == "noise in top-left corner"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "bad_response, match",
+        "bad_response",
         [
-            (
-                {"corrupted": "yes", "description": "x", "votes": 1},
-                "invalid type for 'corrupted'",
-            ),
-            (
-                {"corrupted": True, "description": 123, "votes": 1},
-                "invalid type for 'description'",
-            ),
-            (
-                {"corrupted": True, "description": "x", "votes": "a"},
-                "invalid type for 'votes'",
-            ),
+            {"corrupted": "yes", "description": "x"},
+            {"corrupted": True, "description": 123},
         ],
     )
-    async def test_raises_on_wrong_value_type(
-        self, mock_post, bad_response, match
-    ):
+    async def test_retries_on_wrong_value_type(self, mock_post, bad_response):
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
-        with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value=json.dumps(bad_response),
-            ),
-            pytest.raises(ValueError, match=match),
-        ):
-            await client.detect_corrupted_image(image=image)
+        with patch(
+            "yarf.rf_libraries.libraries.llm_client.LlmClient"
+            ".asyncio.to_thread",
+            side_effect=[
+                json.dumps(bad_response),
+                self.VALID_RESPONSE,
+            ],
+        ) as mock_thread:
+            result = await client.check_for_visual_corruption(
+                image=image,
+            )
+
+        assert mock_thread.call_count == 2
+        assert result["corrupted"] is True
+
+    def test_verify_llm_json_valid(self):
+        client = LlmClient()
+        raw = json.dumps({"corrupted": True, "description": "ok"})
+        parsed, errors = client._verify_llm_json_response(
+            raw,
+            {"corrupted", "description"},
+            {"corrupted": bool, "description": str},
+        )
+        assert parsed == {"corrupted": True, "description": "ok"}
+        assert errors == ""
+
+    def test_verify_llm_json_missing_keys(self):
+        client = LlmClient()
+        raw = json.dumps({"corrupted": True})
+        parsed, errors = client._verify_llm_json_response(
+            raw,
+            {"corrupted", "description"},
+            {"corrupted": bool},
+        )
+        assert "missing keys" in errors
+
+    def test_verify_llm_json_wrong_type(self):
+        client = LlmClient()
+        raw = json.dumps({"corrupted": "yes", "description": "ok"})
+        parsed, errors = client._verify_llm_json_response(
+            raw,
+            {"corrupted", "description"},
+            {"corrupted": bool, "description": str},
+        )
+        assert "invalid type for 'corrupted'" in errors
+
+    def test_verify_llm_json_parse_error(self):
+        client = LlmClient()
+        with pytest.raises(RuntimeError, match="Failed to parse LLM response"):
+            client._verify_llm_json_response(
+                "not json",
+                {"corrupted"},
+                {"corrupted": bool},
+            )

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image
 
-from yarf.errors.yarf_errors import YARFValidationError
+from yarf.errors.yarf_errors import VQAValidationError
 from yarf.rf_libraries.libraries.llm_client.LlmClient import LlmClient
 
 
@@ -218,7 +218,7 @@ class TestLlmClient:
                 return_value=self.CORRUPTED_RESPONSE,
             ),
             pytest.raises(
-                YARFValidationError,
+                VQAValidationError,
                 match="Image is corrupted",
             ),
         ):

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image
 
+from yarf.errors.yarf_errors import YARFValidationError
 from yarf.rf_libraries.libraries.llm_client.LlmClient import LlmClient
 
 
@@ -176,6 +177,13 @@ class TestLlmClient:
 
     VALID_RESPONSE = json.dumps(
         {
+            "corrupted": False,
+            "description": "image looks normal",
+        }
+    )
+
+    CORRUPTED_RESPONSE = json.dumps(
+        {
             "corrupted": True,
             "description": "noise in top-left corner",
         }
@@ -195,8 +203,26 @@ class TestLlmClient:
                 image=image,
             )
 
-        assert result["corrupted"] is True
-        assert result["description"] == "noise in top-left corner"
+        assert result["corrupted"] is False
+        assert result["description"] == "image looks normal"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_corrupted_image(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value=self.CORRUPTED_RESPONSE,
+            ),
+            pytest.raises(
+                YARFValidationError,
+                match="Image is corrupted",
+            ),
+        ):
+            await client.check_for_visual_corruption(image=image)
 
     @pytest.mark.asyncio
     async def test_custom_prompt(self, mock_post):
@@ -208,12 +234,13 @@ class TestLlmClient:
             ".asyncio.to_thread",
             return_value=self.VALID_RESPONSE,
         ) as mock_thread:
-            await client.check_for_visual_corruption(
+            result = await client.check_for_visual_corruption(
                 image=image, custom_prompt="Is this broken?"
             )
 
         mock_thread.assert_called_once()
         assert mock_thread.call_args.kwargs["prompt"] == ("Is this broken?")
+        assert result["corrupted"] is False
 
     @pytest.mark.asyncio
     async def test_grabs_screenshot_when_no_image(self, mock_post):
@@ -237,7 +264,7 @@ class TestLlmClient:
         ):
             result = await client.check_for_visual_corruption()
 
-        assert result["corrupted"] is True
+        assert result["corrupted"] is False
         mock_video.grab_screenshot.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -288,8 +315,8 @@ class TestLlmClient:
             )
 
         assert mock_thread.call_count == 2
-        assert result["corrupted"] is True
-        assert result["description"] == "noise in top-left corner"
+        assert result["corrupted"] is False
+        assert result["description"] == "image looks normal"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -316,7 +343,7 @@ class TestLlmClient:
             )
 
         assert mock_thread.call_count == 2
-        assert result["corrupted"] is True
+        assert result["corrupted"] is False
 
     def test_verify_llm_json_valid(self):
         client = LlmClient()

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -353,7 +353,6 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": True, "description": "ok"})
         parsed, errors = client._verify_llm_json_response(
             raw,
-            {"corrupted", "description"},
             {"corrupted": bool, "description": str},
         )
         assert parsed == {"corrupted": True, "description": "ok"}
@@ -364,8 +363,7 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": True})
         parsed, errors = client._verify_llm_json_response(
             raw,
-            {"corrupted", "description"},
-            {"corrupted": bool},
+            {"corrupted": bool, "description": str},
         )
         assert "missing keys" in errors
 
@@ -374,7 +372,6 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": "yes", "description": "ok"})
         parsed, errors = client._verify_llm_json_response(
             raw,
-            {"corrupted", "description"},
             {"corrupted": bool, "description": str},
         )
         assert "invalid type for 'corrupted'" in errors
@@ -387,7 +384,6 @@ class TestLlmClient:
         ):
             client._verify_llm_json_response(
                 "not json",
-                {"corrupted"},
                 {"corrupted": bool},
             )
 
@@ -396,7 +392,6 @@ class TestLlmClient:
         with pytest.raises(RuntimeError, match="Failed to parse LLM response"):
             client._verify_llm_json_response(
                 "{not json}",
-                {"corrupted"},
                 {"corrupted": bool},
             )
 
@@ -405,7 +400,6 @@ class TestLlmClient:
         raw = 'Here is the result: {"corrupted": false, "description": "ok"}'
         parsed, errors = client._verify_llm_json_response(
             raw,
-            {"corrupted", "description"},
             {"corrupted": bool, "description": str},
         )
         assert parsed == {"corrupted": False, "description": "ok"}

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -45,20 +46,25 @@ class TestLlmClient:
         assert client.endpoint == "/custom/endpoint"
         assert client.max_tokens == 1000
 
-    def test_configure_llm_client_unknown_param(self):
+    @pytest.mark.parametrize(
+        "kwargs, exc_type, match",
+        [
+            (
+                {"unknown_param": "value"},
+                TypeError,
+                "Unknown argument\\(s\\): unknown_param",
+            ),
+            (
+                {"max_tokens": "not_an_int"},
+                ValueError,
+                "Invalid value for max_tokens: not_an_int. Expected type int",
+            ),
+        ],
+    )
+    def test_configure_llm_client_error(self, kwargs, exc_type, match):
         client = LlmClient()
-        with pytest.raises(TypeError) as exc:
-            client.configure_llm_client(unknown_param="value")
-        assert "Unknown argument(s): unknown_param" in str(exc.value)
-
-    def test_configure_llm_client_invalid_type(self):
-        client = LlmClient()
-        with pytest.raises(ValueError) as exc:
-            client.configure_llm_client(max_tokens="not_an_int")
-        assert (
-            "Invalid value for max_tokens: not_an_int. Expected type int"
-            in str(exc.value)
-        )
+        with pytest.raises(exc_type, match=match):
+            client.configure_llm_client(**kwargs)
 
     def test_prompt_text_without_system_prompt(self, mock_post):
         mock_client = MagicMock()
@@ -151,3 +157,165 @@ class TestLlmClient:
         image = Image.new("RGB", (10, 10))
         encoded = LlmClient._encode_image(mock_client, image)
         assert encoded.startswith("data:image/png;base64,")
+
+    VALID_RESPONSE = json.dumps(
+        {
+            "corrupted": True,
+            "description": "noise in top-left corner",
+            "votes": 7,
+        }
+    )
+
+    @pytest.mark.asyncio
+    async def test_valid_response(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch(
+            "yarf.rf_libraries.libraries.llm_client.LlmClient"
+            ".asyncio.to_thread",
+            return_value=self.VALID_RESPONSE,
+        ):
+            result = await client.detect_corrupted_image(image=image)
+
+        assert result["corrupted"] is True
+        assert result["description"] == "noise in top-left corner"
+        assert result["votes"] == 7
+
+    @pytest.mark.asyncio
+    async def test_custom_prompt(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch(
+            "yarf.rf_libraries.libraries.llm_client.LlmClient"
+            ".asyncio.to_thread",
+            return_value=self.VALID_RESPONSE,
+        ) as mock_thread:
+            await client.detect_corrupted_image(
+                image=image, custom_prompt="Is this broken?"
+            )
+
+        mock_thread.assert_called_once()
+        assert mock_thread.call_args.kwargs["prompt"] == ("Is this broken?")
+
+    @pytest.mark.asyncio
+    async def test_grabs_screenshot_when_no_image(self, mock_post):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value=self.VALID_RESPONSE,
+            ),
+        ):
+            result = await client.detect_corrupted_image()
+
+        assert result["corrupted"] is True
+        mock_video.grab_screenshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_screenshot_fails(self, mock_post):
+        client = LlmClient()
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=None)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            pytest.raises(ValueError, match="Failed to grab screenshot"),
+        ):
+            await client.detect_corrupted_image()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_invalid_json(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value="not json at all",
+            ),
+            pytest.raises(ValueError, match="Failed to parse LLM response"),
+        ):
+            await client.detect_corrupted_image(image=image)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_dict_json(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value=json.dumps([1, 2, 3]),
+            ),
+            pytest.raises(ValueError, match="non-dict JSON response"),
+        ):
+            await client.detect_corrupted_image(image=image)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_keys(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value=json.dumps({"corrupted": True}),
+            ),
+            pytest.raises(ValueError, match="missing keys"),
+        ):
+            await client.detect_corrupted_image(image=image)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_response, match",
+        [
+            (
+                {"corrupted": "yes", "description": "x", "votes": 1},
+                "invalid type for 'corrupted'",
+            ),
+            (
+                {"corrupted": True, "description": 123, "votes": 1},
+                "invalid type for 'description'",
+            ),
+            (
+                {"corrupted": True, "description": "x", "votes": "a"},
+                "invalid type for 'votes'",
+            ),
+        ],
+    )
+    async def test_raises_on_wrong_value_type(
+        self, mock_post, bad_response, match
+    ):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                return_value=json.dumps(bad_response),
+            ),
+            pytest.raises(ValueError, match=match),
+        ):
+            await client.detect_corrupted_image(image=image)

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -348,6 +348,27 @@ class TestLlmClient:
         assert mock_thread.call_count == 2
         assert result["corrupted"] is False
 
+    @pytest.mark.asyncio
+    async def test_raises_after_retry_fails(self, mock_post):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+        bad = json.dumps({"corrupted": "yes", "description": "ok"})
+
+        with (
+            patch(
+                "yarf.rf_libraries.libraries.llm_client.LlmClient"
+                ".asyncio.to_thread",
+                side_effect=[bad, bad],
+            ) as mock_thread,
+            pytest.raises(
+                RuntimeError,
+                match="Failing to get a valid response from LLM",
+            ),
+        ):
+            await client.check_for_visual_corruption(image=image)
+
+        assert mock_thread.call_count == 2
+
     def test_verify_llm_json_valid(self):
         client = LlmClient()
         raw = json.dumps({"corrupted": True, "description": "ok"})

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -158,6 +158,22 @@ class TestLlmClient:
         encoded = LlmClient._encode_image(mock_client, image)
         assert encoded.startswith("data:image/png;base64,")
 
+    def test_get_lib_instance(self):
+        client = LlmClient()
+        sentinel = object()
+        with patch(
+            "yarf.rf_libraries.libraries.llm_client.LlmClient.BuiltIn"
+        ) as mock_builtin_cls:
+            mock_builtin_cls.return_value.get_library_instance.return_value = (
+                sentinel
+            )
+            result = client._get_lib_instance("VideoInput")
+
+        mock_builtin_cls.return_value.get_library_instance.assert_called_once_with(
+            "VideoInput"
+        )
+        assert result is sentinel
+
     VALID_RESPONSE = json.dumps(
         {
             "corrupted": True,

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -295,7 +295,10 @@ class TestLlmClient:
                 ".asyncio.to_thread",
                 return_value="not json at all",
             ),
-            pytest.raises(RuntimeError, match="Failed to parse LLM response"),
+            pytest.raises(
+                RuntimeError,
+                match="does not contain valid JSON",
+            ),
         ):
             await client.check_for_visual_corruption(image=image)
 
@@ -376,11 +379,34 @@ class TestLlmClient:
         )
         assert "invalid type for 'corrupted'" in errors
 
-    def test_verify_llm_json_parse_error(self):
+    def test_verify_llm_json_no_braces(self):
         client = LlmClient()
-        with pytest.raises(RuntimeError, match="Failed to parse LLM response"):
+        with pytest.raises(
+            RuntimeError,
+            match="does not contain valid JSON",
+        ):
             client._verify_llm_json_response(
                 "not json",
                 {"corrupted"},
                 {"corrupted": bool},
             )
+
+    def test_verify_llm_json_parse_error(self):
+        client = LlmClient()
+        with pytest.raises(RuntimeError, match="Failed to parse LLM response"):
+            client._verify_llm_json_response(
+                "{not json}",
+                {"corrupted"},
+                {"corrupted": bool},
+            )
+
+    def test_verify_llm_json_extracts_from_text(self):
+        client = LlmClient()
+        raw = 'Here is the result: {"corrupted": false, "description": "ok"}'
+        parsed, errors = client._verify_llm_json_response(
+            raw,
+            {"corrupted", "description"},
+            {"corrupted": bool, "description": str},
+        )
+        assert parsed == {"corrupted": False, "description": "ok"}
+        assert errors == ""


### PR DESCRIPTION
## Description

This PR adds a new keyword to detect corrupted images.

## Resolved issues

[ZAP-1424](https://warthogs.atlassian.net/browse/ZAP-1424)

## Documentation

Added automatically

## Tests

1. Start Ollama Qwen model following: https://canonical-yarf.readthedocs-hosted.com/latest/how-to/using-the-llm-client/
2. Start Mir server.
3. Start YARF Interactive:
```
$ yarf --platform Mir


INFO: *** Welcome to the YARF interactive console. ***
INFO: You can use this console to execute Robot Framework keywords interactively.
INFO: The value of ${CURDIR} is CWD, you can change it using the `Set Variable` keyword.
INFO: You can press RIGHT_ARROW to auto-complete the keyword.
INFO: You can press CRTL + SPACE to view supported keywords on a prefix.
>>>>> Enter interactive shell
iRobot can interpret single or multiple keyword calls,
as well as FOR, IF, WHILE, TRY
and resource file syntax like *** Keywords*** or *** Variables ***.

Type "help" for more information.
> Configure Llm Client   model=qwen3-vl:2b-instruct
> Check For Visual Corruption                                                                                                                                   # ΔT: 0.001s
< {'corrupted': True, 'description': 'The image is entirely black, which is a typical indication of a corrupted or missing image.'}
> Check For Visual Corruption                                                                                                                               # ΔT: 171.163s
< {'corrupted': False, 'description': 'The image shows a file manager window displaying various folders and files on a dark theme, with a proper layout and no signs of corruption or noise.'}
```


[ZAP-1424]: https://warthogs.atlassian.net/browse/ZAP-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ