### PR TITLE
[New] Add LLM-drive GUI navigation

### DIFF
--- a/docs/how-to/using-the-llm-client.md
+++ b/docs/how-to/using-the-llm-client.md
@@ -10,6 +10,7 @@ In this guide, we will cover:
 1. [Setting up an LLM server](#setting-up-an-llm-server)
 1. [Basic text prompting](#basic-text-prompting)
 1. [Using images in prompts](#using-images-in-prompts)
+1. [Using LLM GUI keywords](#using-llm-gui-keywords)
 1. [Configuring the client](#configuring-the-client)
 
 ## Setting up an LLM server
@@ -172,6 +173,10 @@ Structured Response
 The LLM Client supports multi-modal prompts that include both text and images.
 This is particularly useful for visual testing scenarios.
 
+Several image-based keywords can either receive an explicit image or grab a
+fresh screenshot automatically. When the `image` argument is omitted, the LLM
+Client uses the active `VideoInput` library to capture the current screen.
+
 ### Image from file path
 
 ```{code-block} robotframework
@@ -209,6 +214,113 @@ Validate Installation Screen
     
     Should Start With   ${validation}    YES
 ```
+
+## Using VQA GUI keywords
+
+The LLM Client includes keywords that leverage the model's vision capabilities
+to perform visual validation and assertions on the current screen.
+
+### Checking for visual corruption
+
+`Check For Visual Corruption` asks the model whether an image contains visual
+artifacts or corruption. If no image is provided, the keyword grabs a
+screenshot from `VideoInput`.
+
+```{code-block} robotframework
+---
+caption: Check the current screen for visual corruption
+---
+*** Test Cases ***
+Current Screen Is Not Corrupted
+    Check For Visual Corruption
+```
+
+If the model reports corruption, the keyword raises a `VQAValidationError`.
+
+### Asserting screen state
+
+`Assert State` verifies that the screen matches a natural-language description.
+This is useful for checks that are difficult to express with template matching
+or OCR alone.
+
+```{code-block} robotframework
+---
+caption: Assert that the current screen matches an expected state
+---
+*** Test Cases ***
+Desktop Is Visible
+    Assert State    desktop is visible and ready for input
+```
+
+If the model decides that the state does not match, the keyword raises an
+`AssertionError` and includes the model's reasoning in the failure message.
+
+## Using LLM GUI keywords
+
+The LLM Client also provides higher-level keywords for GUI testing. These
+keywords ask a vision-capable model to inspect the current screen and return
+structured results that can be used in Robot Framework tests.
+
+### Locating an object
+
+`Get Object Position` finds a described object on the screen and returns a
+normalized point as `[x, y]`, where each value is relative to the screen size.
+For example, `[0.5, 0.5]` is the center of the screen.
+
+```{code-block} robotframework
+---
+caption: Locate a GUI element with the LLM
+---
+*** Test Cases ***
+Find OK Button
+    ${point}=    Get Object Position    the OK button
+    Log         ${point}
+```
+
+If the object is not found, the keyword raises a `VQAValidationError`.
+
+### Choosing and executing a GUI action
+
+`Get Single Gui Action` asks the model to choose one action for a task. The
+returned action can then be passed to `Execute Gui Action`.
+
+Supported action types are:
+
+- `Left Click`
+- `Right Click`
+- `Double Click`
+- `Write`
+
+```{code-block} robotframework
+---
+caption: Let the LLM choose and execute one GUI action
+---
+*** Test Cases ***
+Click The OK Button
+    ${action}=    Get Single Gui Action    click the OK button
+    Execute Gui Action    ${action}
+```
+
+Pointer actions returned by `Get Single Gui Action` use the model's 1000x1000
+coordinate grid internally. `Execute Gui Action` normalizes that point before
+moving the pointer with the active `HID` library.
+
+For typing text directly, the action contains `action_type=Write` and the text
+to enter:
+
+```{code-block} robotframework
+---
+caption: Ask the LLM to type text into the active field
+---
+*** Test Cases ***
+Type A Search Query
+    ${action}=    Get Single Gui Action    type "network settings"
+    Execute Gui Action    ${action}
+```
+
+When `YARF_LOG_LEVEL` is set to `DEBUG`, the GUI action keywords log the
+screenshot sent to the model, the point selected by the model, and the
+screenshot after an executed action.
 
 ## Configuring the client
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -28,7 +28,7 @@
 <p>Detect if an image is corrupted.</p>
 <p>Args: image: The image to check. If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
-<p>Raises: RuntimeError: If the screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
+<p>Raises: VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
 
 ### Return
 
@@ -76,7 +76,7 @@
 <p>Get the position of an object on the screen in relative coordinates.</p>
 <p>Args: description: Description of the object to locate. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
 <p>Returns: The object position as normalized relative coordinates <code>[x, y]</code>, where each value is typically in the range <code>0..1</code>.</p>
-<p>Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the LLM indicates that the object was not</p>
+<p>Raises: VQAValidationError: If the LLM indicates that the object was not</p>
 
 ### Return
 
@@ -96,7 +96,7 @@
 
 <p>Get a single GUI action from the LLM.</p>
 <p>Args: task: The task description to provide to the LLM. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
-<p>Returns: The next GUI action as returned by the LLM. For pointer-based actions, <span class="name">point_2d</span> contains the raw coordinates from the LLM's 1000x1000 grid. Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. ValueError: If the LLM response contains an unsupported action type or is missing required fields.</p>
+<p>Returns: The next GUI action as returned by the LLM. For pointer-based actions, <span class="name">point_2d</span> contains the raw coordinates from the LLM's 1000x1000 grid. Raises: ValueError: If the LLM response contains an unsupported action type or is missing required fields.</p>
 
 ### Return
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -7,10 +7,26 @@
 
 ## Keywords
 
+### Assert State
+
+<p>Assert that the screen matches a state description.</p>
+<p>Args: description: Description of the expected screen state. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
+<p>Raises: RuntimeError: If a screenshot could not be grabbed. AssertionError: If the state does not match the description.</p>
+
+#### Positional and named arguments
+
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| description | string | | POSITIONAL_OR_NAMED | Yes |
+| image | None | None | POSITIONAL_OR_NAMED | No |
+| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+
+<hr style="border:1px solid grey">
+
 ### Check For Visual Corruption
 
 <p>Detect if an image is corrupted.</p>
-<p>Args: image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
+<p>Args: image: The image to check. If no image is provided, a new screenshot is grabbed. custom_prompt: Optional custom prompt to guide the LLM.</p>
 <p>Returns: A dict containing the LLM's assessment of whether the image is corrupted and a description.</p>
 <p>Raises: RuntimeError: If the screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the image is assessed as corrupted by the LLM.</p>
 
@@ -20,10 +36,10 @@
 
 #### Positional and named arguments
 
-| Name          | Type | Default Value | Kind                | Required |
-| ------------- | ---- | ------------- | ------------------- | -------- |
-| image         | None | None          | POSITIONAL_OR_NAMED | No       |
-| custom_prompt | None | None          | POSITIONAL_OR_NAMED | No       |
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| image | None | None | POSITIONAL_OR_NAMED | No |
+| custom_prompt | None | None | POSITIONAL_OR_NAMED | No |
 
 <hr style="border:1px solid grey">
 
@@ -35,9 +51,65 @@
 
 #### Positional and named arguments
 
-| Name   | Type | Default Value | Kind      | Required |
-| ------ | ---- | ------------- | --------- | -------- |
-| kwargs | Any  |               | VAR_NAMED | No       |
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| kwargs | Any | | VAR_NAMED | No |
+
+<hr style="border:1px solid grey">
+
+### Execute Gui Action
+
+<p>Execute a GUI action as specified by the LLM response.</p>
+<p>Args: action: A dict containing the action_type, text, and point_2d.</p>
+<p>Raises: ValueError: If the action type is unsupported or if required fields are missing.</p>
+
+#### Positional and named arguments
+
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| action | dictionary | | POSITIONAL_OR_NAMED | Yes |
+
+<hr style="border:1px solid grey">
+
+### Get Object Position
+
+<p>Get the position of an object on the screen.</p>
+<p>Args: description: Description of the object to locate. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
+<p>Returns: The model point as <code>[x, y]</code> on a 1000x1000 grid, or <code>[-100, -100]</code> if the object was not found.</p>
+<p>Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the LLM indicates that the object was not</p>
+
+### Return
+
+{'name': 'list', 'typedoc': 'list', 'nested': \[{'name': 'Any', 'typedoc': 'Any', 'nested': [], 'union': False}\], 'union': False}
+
+#### Positional and named arguments
+
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| description | string | | POSITIONAL_OR_NAMED | Yes |
+| image | None | None | POSITIONAL_OR_NAMED | No |
+| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+
+<hr style="border:1px solid grey">
+
+### Get Single Gui Action
+
+<p>Get a single GUI action from the LLM.</p>
+<p>Args: task: The task description to provide to the LLM. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
+<p>Returns: The next GUI action with normalized pointer coordinates.</p>
+<p>Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. ValueError: If the LLM response contains an unsupported action type or is missing required fields.</p>
+
+### Return
+
+{'name': 'dict', 'typedoc': 'dictionary', 'nested': \[{'name': 'str', 'typedoc': 'string', 'nested': [], 'union': False}, {'name': 'Any', 'typedoc': 'Any', 'nested': [], 'union': False}\], 'union': False}
+
+#### Positional and named arguments
+
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| task | string | | POSITIONAL_OR_NAMED | Yes |
+| image | None | None | POSITIONAL_OR_NAMED | No |
+| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
 
 <hr style="border:1px solid grey">
 
@@ -53,8 +125,8 @@
 
 #### Positional and named arguments
 
-| Name          | Type   | Default Value | Kind                | Required |
-| ------------- | ------ | ------------- | ------------------- | -------- |
-| prompt        | string |               | POSITIONAL_OR_NAMED | Yes      |
-| image         | None   | None          | POSITIONAL_OR_NAMED | No       |
-| system_prompt | None   | None          | POSITIONAL_OR_NAMED | No       |
+| Name | Type | Default Value | Kind | Required |
+| --- | --- | --- | --- | --- |
+| prompt | string | | POSITIONAL_OR_NAMED | Yes |
+| image | None | None | POSITIONAL_OR_NAMED | No |
+| system_prompt | None | None | POSITIONAL_OR_NAMED | No |

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -15,11 +15,11 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| description | string | | POSITIONAL_OR_NAMED | Yes |
-| image | None | None | POSITIONAL_OR_NAMED | No |
-| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+| Name                 | Type   | Default Value | Kind                | Required |
+| -------------------- | ------ | ------------- | ------------------- | -------- |
+| description          | string |               | POSITIONAL_OR_NAMED | Yes      |
+| image                | None   | None          | POSITIONAL_OR_NAMED | No       |
+| custom_system_prompt | None   | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -36,10 +36,10 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| image | None | None | POSITIONAL_OR_NAMED | No |
-| custom_prompt | None | None | POSITIONAL_OR_NAMED | No |
+| Name          | Type | Default Value | Kind                | Required |
+| ------------- | ---- | ------------- | ------------------- | -------- |
+| image         | None | None          | POSITIONAL_OR_NAMED | No       |
+| custom_prompt | None | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -51,9 +51,9 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| kwargs | Any | | VAR_NAMED | No |
+| Name   | Type | Default Value | Kind      | Required |
+| ------ | ---- | ------------- | --------- | -------- |
+| kwargs | Any  |               | VAR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -65,17 +65,17 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| action | dictionary | | POSITIONAL_OR_NAMED | Yes |
+| Name   | Type       | Default Value | Kind                | Required |
+| ------ | ---------- | ------------- | ------------------- | -------- |
+| action | dictionary |               | POSITIONAL_OR_NAMED | Yes      |
 
 <hr style="border:1px solid grey">
 
 ### Get Object Position
 
-<p>Get the position of an object on the screen.</p>
+<p>Get the position of an object on the screen in relative coordinates.</p>
 <p>Args: description: Description of the object to locate. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
-<p>Returns: The model point as <code>[x, y]</code> on a 1000x1000 grid, or <code>[-100, -100]</code> if the object was not found.</p>
+<p>Returns: The object position as normalized relative coordinates <code>[x, y]</code>, where each value is typically in the range <code>0..1</code>.</p>
 <p>Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. VQAValidationError: If the LLM indicates that the object was not</p>
 
 ### Return
@@ -84,11 +84,11 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| description | string | | POSITIONAL_OR_NAMED | Yes |
-| image | None | None | POSITIONAL_OR_NAMED | No |
-| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+| Name                 | Type   | Default Value | Kind                | Required |
+| -------------------- | ------ | ------------- | ------------------- | -------- |
+| description          | string |               | POSITIONAL_OR_NAMED | Yes      |
+| image                | None   | None          | POSITIONAL_OR_NAMED | No       |
+| custom_system_prompt | None   | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -96,8 +96,7 @@
 
 <p>Get a single GUI action from the LLM.</p>
 <p>Args: task: The task description to provide to the LLM. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
-<p>Returns: The next GUI action with normalized pointer coordinates.</p>
-<p>Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. ValueError: If the LLM response contains an unsupported action type or is missing required fields.</p>
+<p>Returns: The next GUI action as returned by the LLM. For pointer-based actions, <span class="name">point_2d</span> contains the raw coordinates from the LLM's 1000x1000 grid. Raises: RuntimeError: If a screenshot could not be grabbed or if the LLM response is invalid. ValueError: If the LLM response contains an unsupported action type or is missing required fields.</p>
 
 ### Return
 
@@ -105,11 +104,11 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| task | string | | POSITIONAL_OR_NAMED | Yes |
-| image | None | None | POSITIONAL_OR_NAMED | No |
-| custom_system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+| Name                 | Type   | Default Value | Kind                | Required |
+| -------------------- | ------ | ------------- | ------------------- | -------- |
+| task                 | string |               | POSITIONAL_OR_NAMED | Yes      |
+| image                | None   | None          | POSITIONAL_OR_NAMED | No       |
+| custom_system_prompt | None   | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -125,8 +124,8 @@
 
 #### Positional and named arguments
 
-| Name | Type | Default Value | Kind | Required |
-| --- | --- | --- | --- | --- |
-| prompt | string | | POSITIONAL_OR_NAMED | Yes |
-| image | None | None | POSITIONAL_OR_NAMED | No |
-| system_prompt | None | None | POSITIONAL_OR_NAMED | No |
+| Name          | Type   | Default Value | Kind                | Required |
+| ------------- | ------ | ------------- | ------------------- | -------- |
+| prompt        | string |               | POSITIONAL_OR_NAMED | Yes      |
+| image         | None   | None          | POSITIONAL_OR_NAMED | No       |
+| system_prompt | None   | None          | POSITIONAL_OR_NAMED | No       |

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -11,7 +11,7 @@
 
 <p>Assert that the screen matches a state description.</p>
 <p>Args: description: Description of the expected screen state. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
-<p>Raises: RuntimeError: If a screenshot could not be grabbed. AssertionError: If the state does not match the description.</p>
+<p>Raises: AssertionError: If the state does not match the description.</p>
 
 #### Positional and named arguments
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -76,7 +76,7 @@
 <p>Get the position of an object on the screen in relative coordinates.</p>
 <p>Args: description: Description of the object to locate. image: Image to inspect. If omitted, a screenshot is grabbed. custom_system_prompt: Optional system prompt override.</p>
 <p>Returns: The object position as normalized relative coordinates <code>[x, y]</code>, where each value is typically in the range <code>0..1</code>.</p>
-<p>Raises: VQAValidationError: If the LLM indicates that the object was not</p>
+<p>Raises: VQADetectionError: If the LLM indicates that the object was not</p>
 
 ### Return
 

--- a/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
+++ b/docs/reference/rf_libraries/libraries/llm_client/library-LlmClient.md
@@ -80,7 +80,7 @@
 
 ### Return
 
-{'name': 'list', 'typedoc': 'list', 'nested': \[{'name': 'Any', 'typedoc': 'Any', 'nested': [], 'union': False}\], 'union': False}
+{'name': 'list', 'typedoc': 'list', 'nested': \[{'name': 'float', 'typedoc': 'float', 'nested': [], 'union': False}\], 'union': False}
 
 #### Positional and named arguments
 

--- a/yarf/errors/yarf_errors.py
+++ b/yarf/errors/yarf_errors.py
@@ -38,3 +38,10 @@ class VQAValidationError(Exception):
     """
 
     pass
+
+class VQADetectionError(Exception):
+    """
+    Raised when VQA-driven detection fails.
+    """
+
+    pass

--- a/yarf/errors/yarf_errors.py
+++ b/yarf/errors/yarf_errors.py
@@ -39,6 +39,7 @@ class VQAValidationError(Exception):
 
     pass
 
+
 class VQADetectionError(Exception):
     """
     Raised when VQA-driven detection fails.

--- a/yarf/rf_libraries/libraries/image/tests/test_utils.py
+++ b/yarf/rf_libraries/libraries/image/tests/test_utils.py
@@ -1,6 +1,13 @@
 from unittest.mock import ANY, Mock, patch
 
-from yarf.rf_libraries.libraries.image.utils import log_image
+import pytest
+from PIL import Image
+
+from yarf.rf_libraries.libraries.image.utils import (
+    draw_point_on_image,
+    log_image,
+    normalize_point,
+)
 
 
 class TestImageUtils:
@@ -20,3 +27,77 @@ class TestImageUtils:
         mock_base_64.assert_called_once_with(image)
         mock_logger.info.assert_called_once_with(ANY, html=True)
         assert mock_logger.info.call_args.args[0].startswith("Debug message")
+
+    @pytest.mark.parametrize(
+        "point, expected",
+        [
+            ([0, 0], [0.0, 0.0]),
+            ([250, 500], [0.25, 0.5]),
+            ([1000, 1000], [1.0, 1.0]),
+            (["125", "875"], [0.125, 0.875]),
+        ],
+    )
+    def test_normalize_point(self, point, expected):
+        assert normalize_point(point) == expected
+
+    @pytest.mark.parametrize(
+        "point, match",
+        [
+            ([1], "exactly two coordinates"),
+            ([1, 2, 3], "exactly two coordinates"),
+            (["x", 2], "must be numeric"),
+            ([-100, -100], "object was not found"),
+            ([-1, 500], "inside the screen"),
+            ([500, 1001], "inside the screen"),
+        ],
+    )
+    def test_normalize_point_error(self, point, match):
+        with pytest.raises(ValueError, match=match):
+            normalize_point(point)
+
+    def test_draw_point_on_image_draws_relative_point(self):
+        image = Image.new("RGB", (100, 50), "white")
+
+        result = draw_point_on_image(image, [0.5, 0.5], size=2)
+
+        assert result is not image
+        assert image.getpixel((50, 25)) == (255, 255, 255)
+        assert result.getpixel((50, 25)) == (255, 0, 0)
+        assert result.getpixel((48, 25)) == (255, 0, 0)
+        assert result.getpixel((50, 23)) == (255, 0, 0)
+
+    def test_draw_point_on_image_draws_absolute_point(self):
+        image = Image.new("RGB", (100, 50), "white")
+
+        result = draw_point_on_image(image, [20, 10], size=2)
+
+        assert result.getpixel((20, 10)) == (255, 0, 0)
+        assert result.getpixel((18, 10)) == (255, 0, 0)
+        assert result.getpixel((20, 8)) == (255, 0, 0)
+
+    @patch("yarf.rf_libraries.libraries.image.utils.ImageDraw.Draw")
+    def test_draw_point_on_image_draws_label(self, mock_draw_cls):
+        image = Image.new("RGB", (100, 50), "white")
+        mock_draw = mock_draw_cls.return_value
+
+        result = draw_point_on_image(image, [20, 10], label="target", size=3)
+
+        assert result is not image
+        mock_draw.line.assert_any_call(
+            [(17, 10), (23, 10)], fill="red", width=2
+        )
+        mock_draw.line.assert_any_call(
+            [(20, 7), (20, 13)], fill="red", width=2
+        )
+        mock_draw.text.assert_called_once_with(
+            (27, 3),
+            "target",
+            fill="red",
+            font_size=6,
+        )
+
+    def test_draw_point_on_image_rejects_invalid_point_shape(self):
+        image = Image.new("RGB", (100, 50), "white")
+
+        with pytest.raises(ValueError, match="exactly two coordinates"):
+            draw_point_on_image(image, [1], size=2)

--- a/yarf/rf_libraries/libraries/image/tests/test_utils.py
+++ b/yarf/rf_libraries/libraries/image/tests/test_utils.py
@@ -46,7 +46,6 @@ class TestImageUtils:
             ([1], "exactly two coordinates"),
             ([1, 2, 3], "exactly two coordinates"),
             (["x", 2], "must be numeric"),
-            ([-100, -100], "object was not found"),
             ([-1, 500], "inside the screen"),
             ([500, 1001], "inside the screen"),
         ],

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -50,9 +50,6 @@ def normalize_point(point: list) -> list[float]:
     except (TypeError, ValueError) as exc:
         raise ValueError("Point coordinates must be numeric.") from exc
 
-    if [x, y] == [-100.0, -100.0]:
-        raise ValueError("Point indicates object was not found.")
-
     if not 0 <= x <= 1000 or not 0 <= y <= 1000:
         raise ValueError("Point coordinates must be inside the screen.")
 
@@ -61,7 +58,7 @@ def normalize_point(point: list) -> list[float]:
 
 
 def draw_point_on_image(
-    image: Image.Image,
+    image: Image.Image | str,
     point: list[float] | list[int],
     label: str | None = None,
     size: int = 10,
@@ -81,6 +78,8 @@ def draw_point_on_image(
     Raises:
         ValueError: If the point is not valid.
     """
+    image = to_image(image)
+    
     if len(point) != 2:
         raise ValueError("Point must contain exactly two coordinates.")
 

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -37,6 +37,9 @@ def normalize_point(point: list) -> list[float]:
 
     Returns:
         The point as normalized ``[x, y]`` coordinates.
+
+    Raises:
+        ValueError: If the point is not valid.
     """
     if len(point) != 2:
         raise ValueError("Point must contain exactly two coordinates.")
@@ -70,11 +73,13 @@ def draw_point_on_image(
         image: Pillow image to annotate.
         point: Point in image or relative coordinates to draw
         label: Optional text label to draw near the marker.
-        coordinate_grid: Size of the model coordinate grid.
-        radius: Radius of the circular marker.
+        size: Size of the marker.
 
     Returns:
         Annotated image copy.
+
+    Raises:
+        ValueError: If the point is not valid.
     """
     if len(point) != 2:
         raise ValueError("Point must contain exactly two coordinates.")

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -79,7 +79,7 @@ def draw_point_on_image(
         ValueError: If the point is not valid.
     """
     image = to_image(image)
-    
+
     if len(point) != 2:
         raise ValueError("Point must contain exactly two coordinates.")
 

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -28,6 +28,35 @@ def log_image(image: Image.Image | str, msg: str = "") -> None:
     logger.info(image_string, html=True)
 
 
+def normalize_point(point: list) -> list[float]:
+    """
+    Normalize a point to proportional screen coordinates.
+
+    Args:
+        point: A point as [x, y] on a 1000x1000 grid
+
+    Returns:
+        The point as normalized ``[x, y]`` coordinates.
+    """
+    if len(point) != 2:
+        raise ValueError("Point must contain exactly two coordinates.")
+
+    try:
+        x = float(point[0])
+        y = float(point[1])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Point coordinates must be numeric.") from exc
+
+    if [x, y] == [-100.0, -100.0]:
+        raise ValueError("Point indicates object was not found.")
+
+    if not 0 <= x <= 1000 or not 0 <= y <= 1000:
+        raise ValueError("Point coordinates must be inside the screen.")
+
+    point = [x / 1000, y / 1000]
+    return point
+
+
 def draw_point_on_image(
     image: Image.Image,
     point: list[float] | list[int],

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -107,6 +107,4 @@ def draw_point_on_image(
             font_size=size * 2,
         )
 
-    annotated.show()  # Show the image for debugging purposes
-
     return annotated

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -2,7 +2,7 @@
 Image logging keyword for Robot Framework.
 """
 
-from PIL import Image
+from PIL import Image, ImageDraw
 from robot.api import logger
 from robot.api.deco import keyword
 
@@ -26,3 +26,53 @@ def log_image(image: Image.Image | str, msg: str = "") -> None:
         f'{to_base64(pil_image)}" />'
     )
     logger.info(image_string, html=True)
+
+
+def draw_point_on_image(
+    image: Image.Image,
+    point: list[float] | list[int],
+    label: str | None = None,
+    size: int = 10,
+) -> Image.Image:
+    """
+    Draw a highlighted point marker on a copy of an image.
+
+    Args:
+        image: Pillow image to annotate.
+        point: Point in image or relative coordinates to draw
+        label: Optional text label to draw near the marker.
+        coordinate_grid: Size of the model coordinate grid.
+        radius: Radius of the circular marker.
+
+    Returns:
+        Annotated image copy.
+    """
+    if len(point) != 2:
+        raise ValueError("Point must contain exactly two coordinates.")
+
+    x, y = point
+
+    # Check if the coordinates are relative (between 0 and 1) and convert to
+    # absolute if so
+    if 0 <= x <= 1 and 0 <= y <= 1:
+        width, height = image.size
+        x = round(x * width)
+        y = round(y * height)
+
+    annotated = image.copy()
+    draw = ImageDraw.Draw(annotated)
+
+    draw.line([(x - size, y), (x + size, y)], fill="red", width=2)
+    draw.line([(x, y - size), (x, y + size)], fill="red", width=2)
+
+    if label:
+        draw.text(
+            (x + size + 4, max(0, y - size - 4)),
+            label,
+            fill="red",
+            font_size=size * 2,
+        )
+
+    annotated.show()  # Show the image for debugging purposes
+
+    return annotated

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -618,6 +618,8 @@ class LlmClient:
             raise ValueError(f"Unsupported GUI action: {action_type}")
 
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
+            # Wait for a moment to let the screen update after the action
+            await asyncio.sleep(1)
             image = await self._grab_screenshot()
             logger.info(f"Executed action: {action_type}")
             log_image(image=image, msg="Screenshot after executing action")

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -354,7 +354,7 @@ class LlmClient:
         description: str,
         image: Image.Image | str | None = None,
         custom_system_prompt: str | None = None,
-    ) -> list[Any]:
+    ) -> list[float]:
         """
         Get the position of an object on the screen in relative coordinates.
 

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -5,6 +5,7 @@ server using OpenAPI.
 
 import asyncio
 import json
+import textwrap
 from typing import Any
 
 import requests
@@ -182,11 +183,11 @@ class LlmClient:
             if (image := await platform_video_input.grab_screenshot()) is None:
                 raise RuntimeError("Failed to grab screenshot.")
 
-        result = await asyncio.to_thread(
+        llm_output = await asyncio.to_thread(
             self.prompt_llm,
             prompt=custom_prompt or "Detect if the image is corrupted.",
             image=image,
-            system_prompt="""
+            system_prompt=textwrap.dedent("""
             You are a helpful assistant that can understand images and texts.
             You have to assess if the provided image is corrupted or not.
             This will probably be shown as noise in some parts of the image.
@@ -195,35 +196,14 @@ class LlmClient:
             2. description: a short description (on 1 line)
             Example output: {"corrupted": true, "description": "..."}.
             Do not add markdown syntax or any other text.
-            """,
+            """),
         )
 
-        required_keys = {
-            "corrupted": bool,
-            "description": str,
-        }
-        parsed, error_messages = self._verify_llm_json_response(
-            result, required_keys
+        required_keys = {"corrupted": bool, "description": str}
+
+        parsed = await self._verify_llm_json_response(
+            llm_output, required_keys
         )
-        if len(error_messages) > 0:
-            result = await asyncio.to_thread(
-                self.prompt_llm,
-                prompt=f"""
-                Please correct the previous response and output the correct JSON.
-                Previous response: {result}
-                Error details: {error_messages}
-                """,
-                system_prompt="""
-                You are a helpful assistant that can understand error outputs.
-                Output your answer in JSON format only.
-                Example: {"corrupted": true, "description": "..."}.
-                """,
-            )
-            parsed, errors = self._verify_llm_json_response(
-                result, required_keys
-            )
-            if errors:
-                raise RuntimeError("Failing to get a valid response from LLM")
 
         if parsed["corrupted"]:
             log_image(
@@ -232,39 +212,112 @@ class LlmClient:
             raise VQAValidationError(
                 f"Image is corrupted: {parsed['description']}"
             )
-
         return parsed
 
-    def _verify_llm_json_response(
+    async def _verify_llm_json_response(
         self,
-        result: str,
+        llm_output: str,
         required_keys: dict[str, type],
-    ) -> tuple[dict[str, Any], str]:
-        json_start = result.find("{")
-        json_end = result.rfind("}")
-        if json_start == -1 or json_end == -1:
-            raise RuntimeError(
-                f"LLM response does not contain valid JSON: {result}"
+    ) -> dict[str, Any]:
+        """
+        Verify that the LLM response is a valid JSON object with the required
+        keys and expected types. If there are validation errors, an attempt is
+        made to correct the
+
+        Args:
+            result: The raw string response from the LLM.
+            required_keys: A dict mapping keys to their expected types.
+
+        Returns:
+            The parsed JSON object if it is valid.
+        """
+
+        parsed_output, errors = self._parse_llm_json_response(
+            llm_output, required_keys
+        )
+
+        if errors:
+            logger.warn(
+                f"LLM response had validation errors: {errors}\n"
+                "Trying to fix them with a verification prompt"
             )
+
+            corrected_output = await asyncio.to_thread(
+                self.prompt_llm,
+                prompt=textwrap.dedent(f"""
+                Please correct the previous response and output the correct
+                JSON.
+                Previous response: {llm_output}
+                Error details: {errors}
+                """),
+                system_prompt=textwrap.dedent("""
+                Your task is to understand error outputs and try to fix them
+                by understanding the response.
+                Rules:
+                 - You have to make sure the output is a valid JSON and follows
+                   the required schema.
+                 - The output must be the JSON object without any extra text or
+                   markdown.
+                 - All the brackets and quotes must be properly closed.
+                """),
+            )
+
+            parsed_output, verifier_errors = self._parse_llm_json_response(
+                corrected_output, required_keys
+            )
+
+            if verifier_errors:
+                msg = textwrap.dedent(f"""
+                    LLM response could not be validated even after correction.
+                    Original response: {llm_output}
+                    Errors: {errors}
+                    Corrected response: {corrected_output}
+                    Errors: {verifier_errors}
+                    """)
+                raise RuntimeError(msg)
+
+        return parsed_output
+
+    def _parse_llm_json_response(
+        self, llm_output: str, required_keys: dict[str, type]
+    ) -> tuple[dict[str, Any], str]:
+        """
+        Parse the LLM output as JSON and validate it against the required keys
+        and their expected types.
+        Args:
+            llm_output: The raw string response from the LLM.
+            required_keys: A dict mapping keys to their expected types.
+        Returns:
+            A tuple containing the parsed JSON object and a string of error
+            messages (empty if no errors).
+        """
+        json_start = llm_output.find("{")
+        json_end = llm_output.rfind("}")
+        if json_start == -1 or json_end == -1:
+            error_messages = (
+                f"LLM response does not contain valid JSON: {llm_output}"
+            )
+            return {}, error_messages
 
         try:
-            parsed: dict[str, Any] = json.loads(
-                result[json_start : json_end + 1]
+            parsed_output: dict[str, Any] = json.loads(
+                llm_output[json_start : json_end + 1]
             )
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(
-                f"Failed to parse LLM response as JSON: {result}"
-            ) from exc
+        except json.JSONDecodeError:
+            error_messages = (
+                f"Failed to parse LLM response as JSON: {llm_output}"
+            )
+            return {}, error_messages
 
         error_messages = ""
-        missing_keys = required_keys.keys() - parsed.keys()
+        missing_keys = required_keys.keys() - parsed_output.keys()
         if missing_keys:
             error_messages += (
                 "LLM returned an invalid response format; missing keys: "
-                f"{sorted(missing_keys)}. Response: {parsed}"
+                f"{sorted(missing_keys)}. Response: {parsed_output}"
             )
 
-        for key, value in parsed.items():
+        for key, value in parsed_output.items():
             if key in required_keys and not isinstance(
                 value, required_keys[key]
             ):
@@ -274,6 +327,4 @@ class LlmClient:
                     f"got {type(value).__name__}."
                 )
 
-        if error_messages:
-            logger.warn(f"LLM response validation errors: {error_messages}")
-        return parsed, error_messages
+        return parsed_output, error_messages

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -15,7 +15,7 @@ from robot.api import logger
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
-from yarf.errors.yarf_errors import VQAValidationError
+from yarf.errors.yarf_errors import VQAValidationError, VQADetectionError
 from yarf.lib.images.utils import to_base64
 from yarf.rf_libraries.libraries.image.utils import (
     draw_point_on_image,
@@ -373,7 +373,7 @@ class LlmClient:
 
 
         Raises:
-            VQAValidationError: If the LLM indicates that the object was not
+            VQADetectionError: If the LLM indicates that the object was not
         """
         if image is None:
             image = await self._grab_screenshot()
@@ -409,7 +409,7 @@ class LlmClient:
 
         logger.info(f"LLM indicated point: {point}")
         if point == [-100, -100]:
-            raise VQAValidationError(f"Object was not found: {description}")
+            raise VQADetectionError(f"Object was not found: {description}")
 
         # Normalize the point to have relative coordinates
         point = normalize_point(point)

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -197,8 +197,6 @@ class LlmClient:
             corrupted and a description.
 
         Raises:
-            RuntimeError: If the screenshot could not be grabbed or if the LLM
-                response is invalid.
             VQAValidationError: If the image is assessed as corrupted by the
                 LLM.
         """
@@ -375,8 +373,6 @@ class LlmClient:
 
 
         Raises:
-            RuntimeError: If a screenshot could not be grabbed or if the LLM
-                response is invalid.
             VQAValidationError: If the LLM indicates that the object was not
         """
         if image is None:
@@ -440,7 +436,6 @@ class LlmClient:
             custom_system_prompt: Optional system prompt override.
 
         Raises:
-            RuntimeError: If a screenshot could not be grabbed.
             AssertionError: If the state does not match the description.
         """
 
@@ -500,8 +495,6 @@ class LlmClient:
             actions, `point_2d` contains the raw coordinates from the LLM's
             1000x1000 grid.
         Raises:
-            RuntimeError: If a screenshot could not be grabbed or if the LLM
-                response is invalid.
             ValueError: If the LLM response contains an unsupported action type
                 or is missing required fields.
         """

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -15,7 +15,7 @@ from robot.api import logger
 from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
-from yarf.errors.yarf_errors import VQAValidationError, VQADetectionError
+from yarf.errors.yarf_errors import VQADetectionError, VQAValidationError
 from yarf.lib.images.utils import to_base64
 from yarf.rf_libraries.libraries.image.utils import (
     draw_point_on_image,
@@ -317,22 +317,18 @@ class LlmClient:
         json_start = llm_output.find("{")
         json_end = llm_output.rfind("}")
         if json_start == -1 or json_end == -1:
-            error_messages = (
-                f"LLM response does not contain valid JSON: {llm_output}"
-            )
-            return {}, error_messages
+            error = f"LLM response does not contain valid JSON: {llm_output}"
+            return {}, error
 
         try:
             parsed_output: dict[str, Any] = json.loads(
                 llm_output[json_start : json_end + 1]
             )
         except json.JSONDecodeError:
-            error_messages = (
-                f"Failed to parse LLM response as JSON: {llm_output}"
-            )
-            return {}, error_messages
+            error = f"Failed to parse LLM response as JSON: {llm_output}"
+            return {}, error
 
-        error_messages = []
+        error_messages: list[str] = []
         missing_keys = required_keys.keys() - parsed_output.keys()
         if missing_keys:
             error_messages.append(
@@ -350,7 +346,7 @@ class LlmClient:
                     f"got {type(value).__name__}."
                 )
 
-        return parsed_output, '\n'.join(error_messages)
+        return parsed_output, "\n".join(error_messages)
 
     @keyword
     async def get_object_position(

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -20,6 +20,7 @@ from yarf.lib.images.utils import to_base64
 from yarf.rf_libraries.libraries.image.utils import (
     draw_point_on_image,
     log_image,
+    normalize_point,
 )
 from yarf.vendor.RPA.recognition.utils import to_image
 
@@ -394,7 +395,7 @@ class LlmClient:
             raise VQAValidationError(f"Object was not found: {description}")
 
         # Normalize the point to have relative coordinates
-        point = [coord / 1000 for coord in point]
+        point = normalize_point(point)
 
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
             image = draw_point_on_image(image, point, label=description)
@@ -441,7 +442,9 @@ class LlmClient:
 
         llm_output = await asyncio.to_thread(
             self.prompt_llm,
-            prompt=f"Check if this state is present on the screen: {description}",
+            prompt=(
+                f"Check if this state is present on the screen: {description}"
+            ),
             image=image,
             system_prompt=custom_system_prompt or system_prompt,
         )
@@ -456,3 +459,143 @@ class LlmClient:
                 f"State does NOT match description: {description}. "
                 f"Reasoning: {parsed['reasoning']}"
             )
+
+    @keyword
+    async def get_single_gui_action(
+        self,
+        task: str,
+        image: Image.Image | str | None = None,
+        custom_system_prompt: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get a single GUI action from the LLM.
+
+        Args:
+            task: The task description to provide to the LLM.
+            image: Image to inspect. If omitted, a screenshot is grabbed.
+            custom_system_prompt: Optional system prompt override.
+
+        Returns:
+            The next GUI action with normalized pointer coordinates.
+        """
+
+        if image is None:
+            platform_video_input = self._get_lib_instance("VideoInput")
+            if (image := await platform_video_input.grab_screenshot()) is None:
+                raise RuntimeError("Failed to grab screenshot.")
+
+        if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
+            log_image(
+                image, msg="Screenshot provided to LLM for GUI action decision"
+            )
+
+        system_prompt = textwrap.dedent("""
+            You are a GUI agent. You are given a task and a screenshot of the
+            screen. Choose exactly one next action.
+
+            Available actions:
+
+            action_type: Left Click, text: null, point_2d: [x, y]
+                Explanation: Left click a specific UI element and provide
+                coordinates on a 1000x1000 grid.
+
+            action_type: Right Click, text: null, point_2d: [x, y]
+                Explanation: Right click a specific UI element and provide
+                coordinates on a 1000x1000 grid.
+
+            action_type: Double Click, text: null, point_2d: [x, y]
+                Explanation: Double click a specific UI element and provide
+                coordinates on a 1000x1000 grid.
+
+            action_type: Write, text: Text to enter, point_2d: [-100, -100]
+                Explanation: Type text without moving the pointer.
+
+            Return only a valid JSON object with this exact schema:
+            {
+                "action_type": "one of the available action types",
+                "text": "text to be written, or null if not applicable",
+                "point_2d": [x, y]
+            }
+
+            Rules:
+            - Return point_2d on a 1000x1000 grid where [0, 0] is the top-left
+              and [1000, 1000] is the bottom-right of the image.
+            - Use [-100, -100] when coordinates are not applicable.
+            - Do not add markdown syntax or any other text.
+            """)
+
+        llm_output = await asyncio.to_thread(
+            self.prompt_llm,
+            prompt=task,
+            image=image,
+            system_prompt=custom_system_prompt or system_prompt,
+        )
+
+        parsed = await self._verify_llm_json_response(
+            llm_output,
+            {"action_type": str, "point_2d": list},
+        )
+        action_type = parsed["action_type"]
+        allowed_actions = {
+            "Left Click",
+            "Right Click",
+            "Double Click",
+            "Write",
+        }
+        if action_type not in allowed_actions:
+            raise ValueError(f"Unsupported GUI action: {action_type}")
+
+        if action_type == "Write":
+            if not isinstance(parsed.get("text"), str):
+                raise ValueError("Write actions must include text.")
+            return parsed
+
+        if parsed["point_2d"] == [-100.0, -100.0]:
+            raise ValueError(f"{action_type} actions must include a point.")
+
+        if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
+            point = normalize_point(parsed["point_2d"])
+            annotated = draw_point_on_image(image, point, label=action_type)
+            log_image(annotated, f"LLM indicated action point for: {task}")
+
+        return parsed
+
+    @keyword
+    async def execute_gui_action(self, action: dict[str, Any]) -> None:
+        """
+        Execute a GUI action as specified by the LLM response.
+        Args:
+            action: A dict containing the action_type, text, and point_2d.
+        """
+
+        hid = self._get_lib_instance("HID")
+        action_type = action["action_type"]
+        logger.info(f"Executing action: {action_type}")
+
+        if action_type in {"Left Click", "Right Click", "Double Click"}:
+            x, y = normalize_point(action["point_2d"])
+            await hid.move_pointer_to_proportional(x, y)
+            await asyncio.sleep(0.5)
+
+            if action_type == "Left Click":
+                await hid.click_pointer_button("LEFT")
+            elif action_type == "Right Click":
+                await hid.click_pointer_button("RIGHT")
+            else:
+                await hid.click_pointer_button("LEFT")
+                await asyncio.sleep(0.1)
+                await hid.click_pointer_button("LEFT")
+
+        elif action_type == "Write":
+            if not isinstance(action.get("text"), str):
+                raise ValueError("Write actions must include text.")
+            await hid.type_string(action["text"])
+
+        else:
+            raise ValueError(f"Unsupported GUI action: {action_type}")
+
+        if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
+            platform_video_input = self._get_lib_instance("VideoInput")
+            image = await platform_video_input.grab_screenshot()
+            logger.info(f"Executed action: {action_type}")
+            log_image(image=image, msg="Screenshot after executing action")

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -17,7 +17,10 @@ from robot.libraries.BuiltIn import BuiltIn
 
 from yarf.errors.yarf_errors import VQAValidationError
 from yarf.lib.images.utils import to_base64
-from yarf.rf_libraries.libraries.image.utils import draw_point_on_image, log_image
+from yarf.rf_libraries.libraries.image.utils import (
+    draw_point_on_image,
+    log_image,
+)
 from yarf.vendor.RPA.recognition.utils import to_image
 
 
@@ -398,3 +401,58 @@ class LlmClient:
             log_image(image, f"LLM indicated point for: {description}")
 
         return point
+
+    @keyword
+    async def assert_state(
+        self,
+        description: str,
+        image: Image.Image | str | None = None,
+        custom_system_prompt: str | None = None,
+    ) -> None:
+        """
+        Assert that the screen matches a state description.
+
+        Args:
+            description: Description of the expected screen state.
+            image: Image to inspect. If omitted, a screenshot is grabbed.
+            custom_system_prompt: Optional system prompt override.
+
+        Raises:
+            RuntimeError: If a screenshot could not be grabbed.
+            AssertionError: If the state does not match the description.
+        """
+
+        if image is None:
+            platform_video_input = self._get_lib_instance("VideoInput")
+            if (image := await platform_video_input.grab_screenshot()) is None:
+                raise RuntimeError("Failed to grab screenshot.")
+
+        system_prompt = textwrap.dedent("""
+            You are a GUI agent. Check whether the screenshot matches the
+            description of an expected screen state.
+
+            Return only a valid JSON object with this exact schema:
+            {
+                "matches_description": true | false,
+                "reasoning": "explanation of why the state is present or not"
+            }
+            Do not add markdown syntax or any other text.
+            """)
+
+        llm_output = await asyncio.to_thread(
+            self.prompt_llm,
+            prompt=f"Check if this state is present on the screen: {description}",
+            image=image,
+            system_prompt=custom_system_prompt or system_prompt,
+        )
+
+        parsed = await self._verify_llm_json_response(
+            llm_output,
+            {"matches_description": bool, "reasoning": str},
+        )
+
+        if not parsed["matches_description"]:
+            raise AssertionError(
+                f"State does NOT match description: {description}. "
+                f"Reasoning: {parsed['reasoning']}"
+            )

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -260,7 +260,7 @@ class LlmClient:
 
         if errors:
             logger.warn(
-                f"LLM response had validation errors: {errors}\n"
+                f"LLM response had validation errors: \n{errors}\n"
                 "Trying to fix them with a verification prompt"
             )
 
@@ -332,10 +332,10 @@ class LlmClient:
             )
             return {}, error_messages
 
-        error_messages = ""
+        error_messages = []
         missing_keys = required_keys.keys() - parsed_output.keys()
         if missing_keys:
-            error_messages += (
+            error_messages.append(
                 "LLM returned an invalid response format; missing keys: "
                 f"{sorted(missing_keys)}. Response: {parsed_output}"
             )
@@ -344,13 +344,13 @@ class LlmClient:
             if key in required_keys and not isinstance(
                 value, required_keys[key]
             ):
-                error_messages += (
+                error_messages.append(
                     f"LLM returned an invalid type for '{key}'; "
                     f"expected {required_keys[key].__name__}, "
                     f"got {type(value).__name__}."
                 )
 
-        return parsed_output, error_messages
+        return parsed_output, '\n'.join(error_messages)
 
     @keyword
     async def get_object_position(

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -618,7 +618,6 @@ class LlmClient:
             raise ValueError(f"Unsupported GUI action: {action_type}")
 
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
-            platform_video_input = self._get_lib_instance("VideoInput")
-            image = await platform_video_input.grab_screenshot()
+            image = await self._grab_screenshot()
             logger.info(f"Executed action: {action_type}")
             log_image(image=image, msg="Screenshot after executing action")

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -227,8 +227,8 @@ class LlmClient:
     ) -> dict[str, Any]:
         """
         Verify that the LLM response is a valid JSON object with the required
-        keys and expected types. If there are validation errors, an attempt is
-        made to correct the.
+        keys and expected types. If there are validation errors, it tries to
+        correct its previous response, then validates the corrected JSON.
 
         Args:
             llm_output: The raw string response from the LLM.
@@ -348,7 +348,7 @@ class LlmClient:
         custom_system_prompt: str | None = None,
     ) -> list[Any]:
         """
-        Get the position of an object on the screen.
+        Get the position of an object on the screen in relative coordinates.
 
         Args:
             description: Description of the object to locate.
@@ -356,8 +356,9 @@ class LlmClient:
             custom_system_prompt: Optional system prompt override.
 
         Returns:
-            The model point as ``[x, y]`` on a 1000x1000 grid, or
-            ``[-100, -100]`` if the object was not found.
+            The object position as normalized relative coordinates
+            ``[x, y]``, where each value is typically in the range ``0..1``.
+
 
         Raises:
             RuntimeError: If a screenshot could not be grabbed or if the LLM
@@ -485,8 +486,9 @@ class LlmClient:
             custom_system_prompt: Optional system prompt override.
 
         Returns:
-            The next GUI action with normalized pointer coordinates.
-
+            The next GUI action as returned by the LLM. For pointer-based
+            actions, `point_2d` contains the raw coordinates from the LLM's
+            1000x1000 grid.
         Raises:
             RuntimeError: If a screenshot could not be grabbed or if the LLM
                 response is invalid.

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -375,19 +375,30 @@ class LlmClient:
             image = await self._grab_screenshot()
 
         system_prompt = textwrap.dedent("""
-            You are a GUI agent. Find the position of an object on the screen
-            from a description and a screenshot.
+            You are a GUI localization agent. Given an object description and a
+            screenshot, identify the object's location in the screenshot.
 
             Return only a valid JSON object with this exact schema:
-            {
-                "point_2d": [x, y]
-            }
+            {"point_2d": [x, y]}
+            or:
+            {"point_2d": null}
+            if the object is not present or not confidently identified.
 
-            Use a 1000x1000 coordinate grid where [0, 0] is the top-left and
-            [1000, 1000] is the bottom-right of the image.
-
-            If the object is not found, return {"point_2d": [-100, -100]}.
-            Do not add markdown syntax or any other text.
+            Rules:
+            - Use a normalized 1000x1000 coordinate grid, where [0, 0] is the
+              top-left of the screenshot and [1000, 1000] is the bottom-right.
+            - Return the approximate center point of the described object.
+            - Coordinates must be integers.
+            - If the object is partially visible, return the center of the
+              visible portion.
+            - If multiple matching objects are present, return the best match
+              based on the description and surrounding context.
+            - If the object is not visible, or you are not confident it is
+              present, return: {"point_2d": null}
+            - Do not guess. Prefer null over a low-confidence false
+              positive.
+            - Do not include markdown, explanations, comments, or any text
+              outside the JSON object.
             """)
 
         llm_output = await asyncio.to_thread(
@@ -399,12 +410,12 @@ class LlmClient:
 
         parsed = await self._verify_llm_json_response(
             llm_output,
-            {"point_2d": list},
+            {"point_2d": list | None},
         )
         point = parsed["point_2d"]
 
         logger.info(f"LLM indicated point: {point}")
-        if point == [-100, -100]:
+        if point is None:
             raise VQADetectionError(f"Object was not found: {description}")
 
         # Normalize the point to have relative coordinates
@@ -521,20 +532,20 @@ class LlmClient:
                 Explanation: Double click a specific UI element and provide
                 coordinates on a 1000x1000 grid.
 
-            action_type: Write, text: Text to enter, point_2d: [-100, -100]
+            action_type: Write, text: Text to enter, point_2d: null
                 Explanation: Type text without moving the pointer.
 
             Return only a valid JSON object with this exact schema:
             {
                 "action_type": "one of the available action types",
                 "text": "text to be written, or null if not applicable",
-                "point_2d": [x, y]
+                "point_2d": "[x, y], or null if not applicable"
             }
 
             Rules:
             - Return point_2d on a 1000x1000 grid where [0, 0] is the top-left
               and [1000, 1000] is the bottom-right of the image.
-            - Use [-100, -100] when coordinates are not applicable.
+            - Use null when coordinates are not applicable.
             - Do not add markdown syntax or any other text.
             """)
 
@@ -547,7 +558,7 @@ class LlmClient:
 
         parsed = await self._verify_llm_json_response(
             llm_output,
-            {"action_type": str, "point_2d": list},
+            {"action_type": str, "point_2d": list | None, "text": str | None},
         )
         action_type = parsed["action_type"]
         allowed_actions = {
@@ -564,7 +575,7 @@ class LlmClient:
                 raise ValueError("Write actions must include text.")
             return parsed
 
-        if parsed["point_2d"] == [-100.0, -100.0]:
+        if parsed["point_2d"] is None:
             raise ValueError(f"{action_type} actions must include a point.")
 
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -219,7 +219,10 @@ class LlmClient:
             """),
         )
 
-        required_keys = {"corrupted": bool, "description": str}
+        required_keys: dict[str, list[type]] = {
+            "corrupted": [bool],
+            "description": [str],
+        }
 
         parsed = await self._verify_llm_json_response(
             llm_output, required_keys
@@ -235,7 +238,9 @@ class LlmClient:
         return parsed
 
     async def _verify_llm_json_response(
-        self, llm_output: str, required_keys: dict[str, type]
+        self,
+        llm_output: str,
+        required_keys: dict[str, list[type]],
     ) -> dict[str, Any]:
         """
         Verify that the LLM response is a valid JSON object with the required
@@ -300,8 +305,13 @@ class LlmClient:
 
         return parsed_output
 
+    def _format_expected_types(self, expected_types: list[type]) -> str:
+        return " | ".join(t.__name__ for t in expected_types)
+
     def _parse_llm_json_response(
-        self, llm_output: str, required_keys: dict[str, type]
+        self,
+        llm_output: str,
+        required_keys: dict[str, list[type]],
     ) -> tuple[dict[str, Any], str]:
         """
         Parse the LLM output as JSON and validate it against the required keys
@@ -336,13 +346,16 @@ class LlmClient:
                 f"{sorted(missing_keys)}. Response: {parsed_output}"
             )
 
-        for key, value in parsed_output.items():
-            if key in required_keys and not isinstance(
-                value, required_keys[key]
-            ):
+        for key, expected_types in required_keys.items():
+            if key not in parsed_output:
+                continue
+
+            value = parsed_output[key]
+
+            if not isinstance(value, tuple(expected_types)):
                 error_messages.append(
                     f"LLM returned an invalid type for '{key}'; "
-                    f"expected {required_keys[key].__name__}, "
+                    f"expected {self._format_expected_types(expected_types)}, "
                     f"got {type(value).__name__}."
                 )
 
@@ -410,7 +423,7 @@ class LlmClient:
 
         parsed = await self._verify_llm_json_response(
             llm_output,
-            {"point_2d": list | None},
+            {"point_2d": [list, type(None)]},
         )
         point = parsed["point_2d"]
 
@@ -472,7 +485,7 @@ class LlmClient:
 
         parsed = await self._verify_llm_json_response(
             llm_output,
-            {"matches_description": bool, "reasoning": str},
+            {"matches_description": [bool], "reasoning": [str]},
         )
 
         if not parsed["matches_description"]:
@@ -564,7 +577,11 @@ class LlmClient:
 
         parsed = await self._verify_llm_json_response(
             llm_output,
-            {"action_type": str, "point_2d": list | None, "text": str | None},
+            {
+                "action_type": [str],
+                "point_2d": [list, type(None)],
+                "text": [str, type(None)],
+            },
         )
         action_type = parsed["action_type"]
         allowed_actions = {

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -5,6 +5,7 @@ server using OpenAPI.
 
 import asyncio
 import json
+import os
 import textwrap
 from typing import Any
 
@@ -16,7 +17,7 @@ from robot.libraries.BuiltIn import BuiltIn
 
 from yarf.errors.yarf_errors import VQAValidationError
 from yarf.lib.images.utils import to_base64
-from yarf.rf_libraries.libraries.image.utils import log_image
+from yarf.rf_libraries.libraries.image.utils import draw_point_on_image, log_image
 from yarf.vendor.RPA.recognition.utils import to_image
 
 
@@ -167,7 +168,8 @@ class LlmClient:
         Detect if an image is corrupted.
 
         Args:
-            image: The image to check (PIL Image or path). If no image is provided, a new screenshot is grabbed.
+            image: The image to check. If no image is provided, a new
+                screenshot is grabbed.
             custom_prompt: Optional custom prompt to guide the LLM.
 
         Returns:
@@ -175,8 +177,10 @@ class LlmClient:
             corrupted and a description.
 
         Raises:
-            RuntimeError: If the screenshot could not be grabbed or if the LLM response is invalid.
-            VQAValidationError: If the image is assessed as corrupted by the LLM.
+            RuntimeError: If the screenshot could not be grabbed or if the LLM
+                response is invalid.
+            VQAValidationError: If the image is assessed as corrupted by the
+                LLM.
         """
         if image is None:
             platform_video_input = self._get_lib_instance("VideoInput")
@@ -328,3 +332,69 @@ class LlmClient:
                 )
 
         return parsed_output, error_messages
+
+    @keyword
+    async def get_object_position(
+        self,
+        description: str,
+        image: Image.Image | str | None = None,
+        custom_system_prompt: str | None = None,
+    ) -> list[Any]:
+        """
+        Get the position of an object on the screen.
+
+        Args:
+            description: Description of the object to locate.
+            image: Image to inspect. If omitted, a screenshot is grabbed.
+            custom_system_prompt: Optional system prompt override.
+
+        Returns:
+            The model point as ``[x, y]`` on a 1000x1000 grid, or
+            ``[-100, -100]`` if the object was not found.
+        """
+        if image is None:
+            platform_video_input = self._get_lib_instance("VideoInput")
+            if (image := await platform_video_input.grab_screenshot()) is None:
+                raise RuntimeError("Failed to grab screenshot.")
+
+        system_prompt = textwrap.dedent("""
+            You are a GUI agent. Find the position of an object on the screen
+            from a description and a screenshot.
+
+            Return only a valid JSON object with this exact schema:
+            {
+                "point_2d": [x, y]
+            }
+
+            Use a 1000x1000 coordinate grid where [0, 0] is the top-left and
+            [1000, 1000] is the bottom-right of the image.
+
+            If the object is not found, return {"point_2d": [-100, -100]}.
+            Do not add markdown syntax or any other text.
+            """)
+
+        llm_output = await asyncio.to_thread(
+            self.prompt_llm,
+            prompt=f"Find the position of this object: {description}",
+            image=image,
+            system_prompt=custom_system_prompt or system_prompt,
+        )
+
+        parsed = await self._verify_llm_json_response(
+            llm_output,
+            {"point_2d": list},
+        )
+        point = parsed["point_2d"]
+
+        logger.info(f"LLM indicated point: {point}")
+        if point == [-100, -100]:
+            raise VQAValidationError(f"Object was not found: {description}")
+
+        # Normalize the point to have relative coordinates
+        point = [coord / 1000 for coord in point]
+
+        if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
+            image = draw_point_on_image(image, point, label=description)
+            log_image(image, f"LLM indicated point for: {description}")
+
+        return point

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -162,6 +162,22 @@ class LlmClient:
         """
         return BuiltIn().get_library_instance(lib_name)
 
+    async def _grab_screenshot(self) -> Image.Image:
+        """
+        Helper function to grab a screenshot using the VideoInput library.
+
+        Returns:
+            A PIL Image of the screenshot.
+
+        Raises:
+            RuntimeError: If the screenshot could not be grabbed.
+        """
+        platform_video_input = self._get_lib_instance("VideoInput")
+        image = await platform_video_input.grab_screenshot()
+        if image is None:
+            raise RuntimeError("Failed to grab screenshot.")
+        return image
+
     @keyword
     async def check_for_visual_corruption(
         self,
@@ -187,9 +203,7 @@ class LlmClient:
                 LLM.
         """
         if image is None:
-            platform_video_input = self._get_lib_instance("VideoInput")
-            if (image := await platform_video_input.grab_screenshot()) is None:
-                raise RuntimeError("Failed to grab screenshot.")
+            image = await self._grab_screenshot()
 
         llm_output = await asyncio.to_thread(
             self.prompt_llm,
@@ -366,9 +380,7 @@ class LlmClient:
             VQAValidationError: If the LLM indicates that the object was not
         """
         if image is None:
-            platform_video_input = self._get_lib_instance("VideoInput")
-            if (image := await platform_video_input.grab_screenshot()) is None:
-                raise RuntimeError("Failed to grab screenshot.")
+            image = await self._grab_screenshot()
 
         system_prompt = textwrap.dedent("""
             You are a GUI agent. Find the position of an object on the screen
@@ -433,9 +445,7 @@ class LlmClient:
         """
 
         if image is None:
-            platform_video_input = self._get_lib_instance("VideoInput")
-            if (image := await platform_video_input.grab_screenshot()) is None:
-                raise RuntimeError("Failed to grab screenshot.")
+            image = await self._grab_screenshot()
 
         system_prompt = textwrap.dedent("""
             You are a GUI agent. Check whether the screenshot matches the
@@ -497,9 +507,7 @@ class LlmClient:
         """
 
         if image is None:
-            platform_video_input = self._get_lib_instance("VideoInput")
-            if (image := await platform_video_input.grab_screenshot()) is None:
-                raise RuntimeError("Failed to grab screenshot.")
+            image = await self._grab_screenshot()
 
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
             log_image(
@@ -603,7 +611,7 @@ class LlmClient:
                 await hid.click_pointer_button("LEFT")
             elif action_type == "Right Click":
                 await hid.click_pointer_button("RIGHT")
-            else:
+            elif action_type == "Double Click":
                 await hid.click_pointer_button("LEFT")
                 await asyncio.sleep(0.1)
                 await hid.click_pointer_button("LEFT")

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -223,21 +223,23 @@ class LlmClient:
         return parsed
 
     async def _verify_llm_json_response(
-        self,
-        llm_output: str,
-        required_keys: dict[str, type],
+        self, llm_output: str, required_keys: dict[str, type]
     ) -> dict[str, Any]:
         """
         Verify that the LLM response is a valid JSON object with the required
         keys and expected types. If there are validation errors, an attempt is
-        made to correct the
+        made to correct the.
 
         Args:
-            result: The raw string response from the LLM.
+            llm_output: The raw string response from the LLM.
             required_keys: A dict mapping keys to their expected types.
 
         Returns:
             The parsed JSON object if it is valid.
+
+        Raises:
+            RuntimeError: If the LLM response cannot be validated even after
+                correction attempts.
         """
 
         parsed_output, errors = self._parse_llm_json_response(
@@ -292,6 +294,7 @@ class LlmClient:
         """
         Parse the LLM output as JSON and validate it against the required keys
         and their expected types.
+
         Args:
             llm_output: The raw string response from the LLM.
             required_keys: A dict mapping keys to their expected types.
@@ -355,6 +358,11 @@ class LlmClient:
         Returns:
             The model point as ``[x, y]`` on a 1000x1000 grid, or
             ``[-100, -100]`` if the object was not found.
+
+        Raises:
+            RuntimeError: If a screenshot could not be grabbed or if the LLM
+                response is invalid.
+            VQAValidationError: If the LLM indicates that the object was not
         """
         if image is None:
             platform_video_input = self._get_lib_instance("VideoInput")
@@ -455,6 +463,7 @@ class LlmClient:
         )
 
         if not parsed["matches_description"]:
+            log_image(image=image, msg="Current state")
             raise AssertionError(
                 f"State does NOT match description: {description}. "
                 f"Reasoning: {parsed['reasoning']}"
@@ -477,6 +486,12 @@ class LlmClient:
 
         Returns:
             The next GUI action with normalized pointer coordinates.
+
+        Raises:
+            RuntimeError: If a screenshot could not be grabbed or if the LLM
+                response is invalid.
+            ValueError: If the LLM response contains an unsupported action type
+                or is missing required fields.
         """
 
         if image is None:
@@ -564,8 +579,13 @@ class LlmClient:
     async def execute_gui_action(self, action: dict[str, Any]) -> None:
         """
         Execute a GUI action as specified by the LLM response.
+
         Args:
             action: A dict containing the action_type, text, and point_2d.
+
+        Raises:
+            ValueError: If the action type is unsupported or if required fields
+                are missing.
         """
 
         hid = self._get_lib_instance("HID")

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -535,6 +535,10 @@ class LlmClient:
             action_type: Write, text: Text to enter, point_2d: null
                 Explanation: Type text without moving the pointer.
 
+            action_type: Failed, text: null, point_2d: null
+                Explanation: An action is impossible and cannot be performed.
+                This should whenever the model can't determine a valid action.
+
             Return only a valid JSON object with this exact schema:
             {
                 "action_type": "one of the available action types",
@@ -547,6 +551,8 @@ class LlmClient:
               and [1000, 1000] is the bottom-right of the image.
             - Use null when coordinates are not applicable.
             - Do not add markdown syntax or any other text.
+            - If you determine that the task cannot be completed, return:
+              {"action_type": "Failed", "text": null, "point_2d": null}.
             """)
 
         llm_output = await asyncio.to_thread(
@@ -566,9 +572,13 @@ class LlmClient:
             "Right Click",
             "Double Click",
             "Write",
+            "Failed",
         }
         if action_type not in allowed_actions:
             raise ValueError(f"Unsupported GUI action: {action_type}")
+
+        if action_type == "Failed":
+            raise ValueError(f"LLM indicated task can't be completed: {task}.")
 
         if action_type == "Write":
             if not isinstance(parsed.get("text"), str):

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -228,7 +228,7 @@ class TestLlmClient:
     )
 
     OBJECT_FOUND_RESPONSE = json.dumps({"point_2d": [250, 500]})
-    OBJECT_NOT_FOUND_RESPONSE = json.dumps({"point_2d": [-100, -100]})
+    OBJECT_NOT_FOUND_RESPONSE = json.dumps({"point_2d": None})
     STATE_MATCH_RESPONSE = json.dumps(
         {"matches_description": True, "reasoning": "state is present"}
     )
@@ -246,7 +246,7 @@ class TestLlmClient:
         {
             "action_type": "Write",
             "text": "hello",
-            "point_2d": [-100, -100],
+            "point_2d": None,
         }
     )
 
@@ -786,7 +786,7 @@ class TestLlmClient:
         assert action == {
             "action_type": "Write",
             "text": "hello",
-            "point_2d": [-100, -100],
+            "point_2d": None,
         }
 
     @pytest.mark.asyncio
@@ -798,7 +798,7 @@ class TestLlmClient:
                 {
                     "action_type": "Write",
                     "text": None,
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 },
                 "Write actions must include text.",
             ),
@@ -807,16 +807,25 @@ class TestLlmClient:
                 {
                     "action_type": "Wait",
                     "text": None,
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 },
                 "Unsupported GUI action: Wait",
+            ),
+            (
+                "fail",
+                {
+                    "action_type": "Failed",
+                    "text": None,
+                    "point_2d": None,
+                },
+                "LLM indicated task can't be completed: fail.",
             ),
             (
                 "click OK",
                 {
                     "action_type": "Left Click",
                     "text": None,
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 },
                 "Left Click actions must include a point.",
             ),
@@ -966,7 +975,7 @@ class TestLlmClient:
                 {
                     "action_type": "Write",
                     "text": "hello",
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 }
             )
 
@@ -980,7 +989,7 @@ class TestLlmClient:
                 {
                     "action_type": "Write",
                     "text": None,
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 },
                 "Write actions must include text.",
             ),
@@ -988,7 +997,7 @@ class TestLlmClient:
                 {
                     "action_type": "Wait",
                     "text": None,
-                    "point_2d": [-100, -100],
+                    "point_2d": None,
                 },
                 "Unsupported GUI action: Wait",
             ),

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -790,6 +790,55 @@ class TestLlmClient:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "task, response, expected_error",
+        [
+            (
+                "type hello",
+                {
+                    "action_type": "Write",
+                    "text": None,
+                    "point_2d": [-100, -100],
+                },
+                "Write actions must include text.",
+            ),
+            (
+                "wait",
+                {
+                    "action_type": "Wait",
+                    "text": None,
+                    "point_2d": [-100, -100],
+                },
+                "Unsupported GUI action: Wait",
+            ),
+            (
+                "click OK",
+                {
+                    "action_type": "Left Click",
+                    "text": None,
+                    "point_2d": [-100, -100],
+                },
+                "Left Click actions must include a point.",
+            ),
+        ],
+    )
+    async def test_get_single_gui_action_rejects_invalid_action(
+        self, task, response, expected_error
+    ):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=json.dumps(response),
+            ),
+            pytest.raises(ValueError, match=expected_error),
+        ):
+            await client.get_single_gui_action(task, image)
+
+    @pytest.mark.asyncio
     async def test_get_single_gui_action_grabs_screenshot_when_no_image(self):
         client = LlmClient()
         screenshot = Image.new("RGB", (10, 10))
@@ -836,40 +885,65 @@ class TestLlmClient:
         )
 
     @pytest.mark.asyncio
-    async def test_get_single_gui_action_rejects_unsupported_action(self):
+    async def test_get_single_gui_action_logs_point_in_debug(self):
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
-        response = json.dumps(
-            {"action_type": "Wait", "text": None, "point_2d": [-100, -100]}
-        )
+        annotated = Image.new("RGB", (10, 10))
 
         with (
-            patch.object(client, "prompt_llm", return_value=response),
-            pytest.raises(ValueError, match="Unsupported GUI action: Wait"),
+            patch.dict("os.environ", {"YARF_LOG_LEVEL": "DEBUG"}),
+            patch(f"{self.LLM_PATH}.log_image") as mock_log_image,
+            patch(
+                f"{self.LLM_PATH}.draw_point_on_image",
+                return_value=annotated,
+            ) as mock_draw_point,
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.CLICK_ACTION_RESPONSE,
+            ),
         ):
-            await client.get_single_gui_action("wait", image)
+            action = await client.get_single_gui_action("click OK", image)
+
+        assert action["point_2d"] == [250, 500]
+        mock_draw_point.assert_called_once_with(
+            image,
+            [0.25, 0.5],
+            label="Left Click",
+        )
+        mock_log_image.assert_any_call(
+            image,
+            msg="Screenshot provided to LLM for GUI action decision",
+        )
+        mock_log_image.assert_any_call(
+            annotated,
+            "LLM indicated action point for: click OK",
+        )
 
     @pytest.mark.asyncio
-    async def test_execute_gui_action_left_click_uses_normalized_point(self):
+    @pytest.mark.parametrize(
+        "action_type, expected_buttons",
+        [
+            ("Left Click", ["LEFT"]),
+            ("Right Click", ["RIGHT"]),
+            ("Double Click", ["LEFT", "LEFT"]),
+        ],
+    )
+    async def test_execute_gui_action_pointer_actions(
+        self, action_type, expected_buttons
+    ):
         client = LlmClient()
         mock_hid = MagicMock()
         mock_hid.move_pointer_to_proportional = AsyncMock()
         mock_hid.click_pointer_button = AsyncMock()
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(
-            return_value=Image.new("RGB", (10, 10))
-        )
-
-        def get_library(name):
-            return {"HID": mock_hid, "VideoInput": mock_video}[name]
-
-        with patch.object(
-            client, "_get_lib_instance", side_effect=get_library
+        with (
+            patch.object(client, "_get_lib_instance", return_value=mock_hid),
+            patch(f"{self.LLM_PATH}.asyncio.sleep", AsyncMock()),
         ):
             await client.execute_gui_action(
                 {
-                    "action_type": "Left Click",
+                    "action_type": action_type,
                     "text": None,
                     "point_2d": [250, 500],
                 }
@@ -878,39 +952,8 @@ class TestLlmClient:
         mock_hid.move_pointer_to_proportional.assert_awaited_once_with(
             0.25, 0.5
         )
-        mock_hid.click_pointer_button.assert_awaited_once_with("LEFT")
-        mock_video.grab_screenshot.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_execute_gui_action_accepts_legacy_grid_point(self):
-        client = LlmClient()
-        mock_hid = MagicMock()
-        mock_hid.move_pointer_to_proportional = AsyncMock()
-        mock_hid.click_pointer_button = AsyncMock()
-
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(
-            return_value=Image.new("RGB", (10, 10))
-        )
-
-        def get_library(name):
-            return {"HID": mock_hid, "VideoInput": mock_video}[name]
-
-        with patch.object(
-            client, "_get_lib_instance", side_effect=get_library
-        ):
-            await client.execute_gui_action(
-                {
-                    "action_type": "Right Click",
-                    "text": None,
-                    "point_2d": [250, 500],
-                }
-            )
-
-        mock_hid.move_pointer_to_proportional.assert_awaited_once_with(
-            0.25, 0.5
-        )
-        mock_hid.click_pointer_button.assert_awaited_once_with("RIGHT")
+        click_args = mock_hid.click_pointer_button.await_args_list
+        assert [call.args[0] for call in click_args] == expected_buttons
 
     @pytest.mark.asyncio
     async def test_execute_gui_action_writes_text(self):
@@ -918,17 +961,7 @@ class TestLlmClient:
         mock_hid = MagicMock()
         mock_hid.type_string = AsyncMock()
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(
-            return_value=Image.new("RGB", (10, 10))
-        )
-
-        def get_library(name):
-            return {"HID": mock_hid, "VideoInput": mock_video}[name]
-
-        with patch.object(
-            client, "_get_lib_instance", side_effect=get_library
-        ):
+        with patch.object(client, "_get_lib_instance", return_value=mock_hid):
             await client.execute_gui_action(
                 {
                     "action_type": "Write",
@@ -938,3 +971,74 @@ class TestLlmClient:
             )
 
         mock_hid.type_string.assert_awaited_once_with("hello")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "action, expected_error",
+        [
+            (
+                {
+                    "action_type": "Write",
+                    "text": None,
+                    "point_2d": [-100, -100],
+                },
+                "Write actions must include text.",
+            ),
+            (
+                {
+                    "action_type": "Wait",
+                    "text": None,
+                    "point_2d": [-100, -100],
+                },
+                "Unsupported GUI action: Wait",
+            ),
+        ],
+    )
+    async def test_execute_gui_action_rejects_invalid_action(
+        self, action, expected_error
+    ):
+        client = LlmClient()
+        mock_hid = MagicMock()
+
+        with (
+            patch.object(client, "_get_lib_instance", return_value=mock_hid),
+            pytest.raises(ValueError, match=expected_error),
+        ):
+            await client.execute_gui_action(action)
+
+    @pytest.mark.asyncio
+    async def test_execute_gui_action_logs_screenshot_in_debug(self):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+        mock_hid = MagicMock()
+        mock_hid.move_pointer_to_proportional = AsyncMock()
+        mock_hid.click_pointer_button = AsyncMock()
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        def get_library(name):
+            return {"HID": mock_hid, "VideoInput": mock_video}[name]
+
+        with (
+            patch.dict("os.environ", {"YARF_LOG_LEVEL": "DEBUG"}),
+            patch.object(
+                client,
+                "_get_lib_instance",
+                side_effect=get_library,
+            ),
+            patch(f"{self.LLM_PATH}.asyncio.sleep", AsyncMock()),
+            patch(f"{self.LLM_PATH}.log_image") as mock_log_image,
+        ):
+            await client.execute_gui_action(
+                {
+                    "action_type": "Left Click",
+                    "text": None,
+                    "point_2d": [250, 500],
+                }
+            )
+
+        mock_video.grab_screenshot.assert_awaited_once()
+        mock_log_image.assert_called_once_with(
+            image=screenshot,
+            msg="Screenshot after executing action",
+        )

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image
 
-from yarf.errors.yarf_errors import VQAValidationError
+from yarf.errors.yarf_errors import VQAValidationError, VQADetectionError
 from yarf.rf_libraries.libraries.llm_client.LlmClient import LlmClient
 
 
@@ -573,7 +573,7 @@ class TestLlmClient:
                 return_value=self.OBJECT_NOT_FOUND_RESPONSE,
             ),
             pytest.raises(
-                VQAValidationError,
+                VQADetectionError,
                 match="Object was not found: missing thing",
             ),
         ):

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -194,10 +194,9 @@ class TestLlmClient:
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
-        with patch(
-            "yarf.rf_libraries.libraries.llm_client.LlmClient"
-            ".asyncio.to_thread",
-            return_value=self.VALID_RESPONSE,
+        # LLM returns valid response on first try
+        with patch.object(
+            client, "prompt_llm", return_value=self.VALID_RESPONSE
         ):
             result = await client.check_for_visual_corruption(
                 image=image,
@@ -211,16 +210,12 @@ class TestLlmClient:
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
+        # LLM detects corruption
         with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value=self.CORRUPTED_RESPONSE,
+            patch.object(
+                client, "prompt_llm", return_value=self.CORRUPTED_RESPONSE
             ),
-            pytest.raises(
-                VQAValidationError,
-                match="Image is corrupted",
-            ),
+            pytest.raises(VQAValidationError, match="Image is corrupted"),
         ):
             await client.check_for_visual_corruption(image=image)
 
@@ -229,17 +224,16 @@ class TestLlmClient:
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
-        with patch(
-            "yarf.rf_libraries.libraries.llm_client.LlmClient"
-            ".asyncio.to_thread",
-            return_value=self.VALID_RESPONSE,
-        ) as mock_thread:
+        # LLM returns valid response to custom prompt
+        with patch.object(
+            client, "prompt_llm", return_value=self.VALID_RESPONSE
+        ) as mock_prompt:
             result = await client.check_for_visual_corruption(
                 image=image, custom_prompt="Is this broken?"
             )
 
-        mock_thread.assert_called_once()
-        assert mock_thread.call_args.kwargs["prompt"] == ("Is this broken?")
+        mock_prompt.assert_called_once()
+        assert mock_prompt.call_args.kwargs["prompt"] == "Is this broken?"
         assert result["corrupted"] is False
 
     @pytest.mark.asyncio
@@ -250,16 +244,11 @@ class TestLlmClient:
         mock_video = MagicMock()
         mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
 
+        # LLM returns valid response for grabbed screenshot
         with (
+            patch.object(client, "_get_lib_instance", return_value=mock_video),
             patch.object(
-                client,
-                "_get_lib_instance",
-                return_value=mock_video,
-            ),
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value=self.VALID_RESPONSE,
+                client, "prompt_llm", return_value=self.VALID_RESPONSE
             ),
         ):
             result = await client.check_for_visual_corruption()
@@ -274,12 +263,9 @@ class TestLlmClient:
         mock_video = MagicMock()
         mock_video.grab_screenshot = AsyncMock(return_value=None)
 
+        # LLM check raises error when screenshot cannot be grabbed
         with (
-            patch.object(
-                client,
-                "_get_lib_instance",
-                return_value=mock_video,
-            ),
+            patch.object(client, "_get_lib_instance", return_value=mock_video),
             pytest.raises(RuntimeError, match="Failed to grab screenshot"),
         ):
             await client.check_for_visual_corruption()
@@ -289,15 +275,12 @@ class TestLlmClient:
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
+        # LLM returns invalid JSON
         with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                return_value="not json at all",
-            ),
+            patch.object(client, "prompt_llm", return_value="not json at all"),
             pytest.raises(
                 RuntimeError,
-                match="does not contain valid JSON",
+                match="could not be validated even after correction",
             ),
         ):
             await client.check_for_visual_corruption(image=image)
@@ -308,16 +291,13 @@ class TestLlmClient:
         image = Image.new("RGB", (10, 10))
         bad = json.dumps({"corrupted": "yes", "description": "ok"})
 
-        with patch(
-            "yarf.rf_libraries.libraries.llm_client.LlmClient"
-            ".asyncio.to_thread",
-            side_effect=[bad, self.VALID_RESPONSE],
-        ) as mock_thread:
-            result = await client.check_for_visual_corruption(
-                image=image,
-            )
+        # LLM returns wrong type for 'corrupted' key, then corrects on retry
+        with patch.object(
+            client, "prompt_llm", side_effect=[bad, self.VALID_RESPONSE]
+        ) as mock_prompt:
+            result = await client.check_for_visual_corruption(image=image)
 
-        assert mock_thread.call_count == 2
+        assert mock_prompt.call_count == 2
         assert result["corrupted"] is False
         assert result["description"] == "image looks normal"
 
@@ -333,19 +313,15 @@ class TestLlmClient:
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
-        with patch(
-            "yarf.rf_libraries.libraries.llm_client.LlmClient"
-            ".asyncio.to_thread",
-            side_effect=[
-                json.dumps(bad_response),
-                self.VALID_RESPONSE,
-            ],
-        ) as mock_thread:
-            result = await client.check_for_visual_corruption(
-                image=image,
-            )
+        # LLM returns wrong value type, then corrects on retry
+        with patch.object(
+            client,
+            "prompt_llm",
+            side_effect=[json.dumps(bad_response), self.VALID_RESPONSE],
+        ) as mock_prompt:
+            result = await client.check_for_visual_corruption(image=image)
 
-        assert mock_thread.call_count == 2
+        assert mock_prompt.call_count == 2
         assert result["corrupted"] is False
 
     @pytest.mark.asyncio
@@ -354,74 +330,148 @@ class TestLlmClient:
         image = Image.new("RGB", (10, 10))
         bad = json.dumps({"corrupted": "yes", "description": "ok"})
 
+        # LLM returns fails twice, leading to error
         with (
-            patch(
-                "yarf.rf_libraries.libraries.llm_client.LlmClient"
-                ".asyncio.to_thread",
-                side_effect=[bad, bad],
-            ) as mock_thread,
+            patch.object(
+                client, "prompt_llm", side_effect=[bad, bad]
+            ) as mock_prompt,
             pytest.raises(
                 RuntimeError,
-                match="Failing to get a valid response from LLM",
+                match="could not be validated even after correction",
             ),
         ):
             await client.check_for_visual_corruption(image=image)
 
-        assert mock_thread.call_count == 2
+        assert mock_prompt.call_count == 2
 
-    def test_verify_llm_json_valid(self):
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_valid(self):
         client = LlmClient()
         raw = json.dumps({"corrupted": True, "description": "ok"})
-        parsed, errors = client._verify_llm_json_response(
+        parsed = await client._verify_llm_json_response(
             raw,
             {"corrupted": bool, "description": str},
         )
         assert parsed == {"corrupted": True, "description": "ok"}
-        assert errors == ""
 
-    def test_verify_llm_json_missing_keys(self):
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_corrects_missing_keys(self):
         client = LlmClient()
         raw = json.dumps({"corrupted": True})
-        parsed, errors = client._verify_llm_json_response(
+
+        # LLM returns missing keys, then corrects on retry
+        with patch.object(
+            client, "prompt_llm", return_value=self.VALID_RESPONSE
+        ) as mock_prompt:
+            parsed = await client._verify_llm_json_response(
+                raw,
+                {"corrupted": bool, "description": str},
+            )
+
+        mock_prompt.assert_called_once()
+        assert parsed == {
+            "corrupted": False,
+            "description": "image looks normal",
+        }
+
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_corrects_wrong_type(self):
+        client = LlmClient()
+        raw = json.dumps({"corrupted": "yes", "description": "ok"})
+
+        # LLM returns wrong type for 'corrupted' key, then corrects on retry
+        with patch.object(
+            client, "prompt_llm", return_value=self.VALID_RESPONSE
+        ) as mock_prompt:
+            parsed = await client._verify_llm_json_response(
+                raw,
+                {"corrupted": bool, "description": str},
+            )
+
+        mock_prompt.assert_called_once()
+        assert parsed == {
+            "corrupted": False,
+            "description": "image looks normal",
+        }
+
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_no_braces(self):
+        client = LlmClient()
+
+        # LLM returns invalid JSON without braces, then fails on retry
+        with (
+            patch.object(client, "prompt_llm", return_value="still not json"),
+            pytest.raises(
+                RuntimeError,
+                match="could not be validated even after correction",
+            ),
+        ):
+            await client._verify_llm_json_response(
+                "not json",
+                {"corrupted": bool},
+            )
+
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_parse_error(self):
+        client = LlmClient()
+
+        # LLM returns invalid JSON with parse error, then fails on retry
+        with (
+            patch.object(
+                client, "prompt_llm", return_value="{still not json}"
+            ),
+            pytest.raises(
+                RuntimeError,
+                match="could not be validated even after correction",
+            ),
+        ):
+            await client._verify_llm_json_response(
+                "{not json}",
+                {"corrupted": bool},
+            )
+
+    @pytest.mark.asyncio
+    async def test_verify_llm_json_extracts_from_text(self):
+        client = LlmClient()
+        raw = 'Here is the result: {"corrupted": false, "description": "ok"}'
+
+        # LLM returns valid JSON embedded in text
+        parsed = await client._verify_llm_json_response(
+            raw,
+            {"corrupted": bool, "description": str},
+        )
+        assert parsed == {"corrupted": False, "description": "ok"}
+
+    def test_parse_llm_json_missing_keys(self):
+        client = LlmClient()
+        raw = json.dumps({"corrupted": True})
+        _parsed, errors = client._parse_llm_json_response(
             raw,
             {"corrupted": bool, "description": str},
         )
         assert "missing keys" in errors
 
-    def test_verify_llm_json_wrong_type(self):
+    def test_parse_llm_json_wrong_type(self):
         client = LlmClient()
         raw = json.dumps({"corrupted": "yes", "description": "ok"})
-        parsed, errors = client._verify_llm_json_response(
+        _parsed, errors = client._parse_llm_json_response(
             raw,
             {"corrupted": bool, "description": str},
         )
         assert "invalid type for 'corrupted'" in errors
 
-    def test_verify_llm_json_no_braces(self):
+    def test_parse_llm_json_no_braces(self):
         client = LlmClient()
-        with pytest.raises(
-            RuntimeError,
-            match="does not contain valid JSON",
-        ):
-            client._verify_llm_json_response(
-                "not json",
-                {"corrupted": bool},
-            )
-
-    def test_verify_llm_json_parse_error(self):
-        client = LlmClient()
-        with pytest.raises(RuntimeError, match="Failed to parse LLM response"):
-            client._verify_llm_json_response(
-                "{not json}",
-                {"corrupted": bool},
-            )
-
-    def test_verify_llm_json_extracts_from_text(self):
-        client = LlmClient()
-        raw = 'Here is the result: {"corrupted": false, "description": "ok"}'
-        parsed, errors = client._verify_llm_json_response(
-            raw,
-            {"corrupted": bool, "description": str},
+        _parsed, errors = client._parse_llm_json_response(
+            "not json",
+            {"corrupted": bool},
         )
-        assert parsed == {"corrupted": False, "description": "ok"}
-        assert errors == ""
+        assert "does not contain valid JSON" in errors
+
+    def test_parse_llm_json_parse_error(self):
+        client = LlmClient()
+        _parsed, errors = client._parse_llm_json_response(
+            "{not json}",
+            {"corrupted": bool},
+        )
+        assert "Failed to parse LLM response" in errors

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -414,7 +414,7 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": True, "description": "ok"})
         parsed = await client._verify_llm_json_response(
             raw,
-            {"corrupted": bool, "description": str},
+            {"corrupted": [bool], "description": [str]},
         )
         assert parsed == {"corrupted": True, "description": "ok"}
 
@@ -429,7 +429,7 @@ class TestLlmClient:
         ) as mock_prompt:
             parsed = await client._verify_llm_json_response(
                 raw,
-                {"corrupted": bool, "description": str},
+                {"corrupted": [bool], "description": [str]},
             )
 
         mock_prompt.assert_called_once()
@@ -449,7 +449,7 @@ class TestLlmClient:
         ) as mock_prompt:
             parsed = await client._verify_llm_json_response(
                 raw,
-                {"corrupted": bool, "description": str},
+                {"corrupted": [bool], "description": [str]},
             )
 
         mock_prompt.assert_called_once()
@@ -472,7 +472,7 @@ class TestLlmClient:
         ):
             await client._verify_llm_json_response(
                 "not json",
-                {"corrupted": bool},
+                {"corrupted": [bool]},
             )
 
     @pytest.mark.asyncio
@@ -491,7 +491,7 @@ class TestLlmClient:
         ):
             await client._verify_llm_json_response(
                 "{not json}",
-                {"corrupted": bool},
+                {"corrupted": [bool]},
             )
 
     @pytest.mark.asyncio
@@ -502,7 +502,7 @@ class TestLlmClient:
         # LLM returns valid JSON embedded in text
         parsed = await client._verify_llm_json_response(
             raw,
-            {"corrupted": bool, "description": str},
+            {"corrupted": [bool], "description": [str]},
         )
         assert parsed == {"corrupted": False, "description": "ok"}
 
@@ -511,7 +511,7 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": True})
         _parsed, errors = client._parse_llm_json_response(
             raw,
-            {"corrupted": bool, "description": str},
+            {"corrupted": [bool], "description": [str]},
         )
         assert "missing keys" in errors
 
@@ -520,7 +520,7 @@ class TestLlmClient:
         raw = json.dumps({"corrupted": "yes", "description": "ok"})
         _parsed, errors = client._parse_llm_json_response(
             raw,
-            {"corrupted": bool, "description": str},
+            {"corrupted": [bool], "description": [str]},
         )
         assert "invalid type for 'corrupted'" in errors
 
@@ -528,7 +528,7 @@ class TestLlmClient:
         client = LlmClient()
         _parsed, errors = client._parse_llm_json_response(
             "not json",
-            {"corrupted": bool},
+            {"corrupted": [bool]},
         )
         assert "does not contain valid JSON" in errors
 
@@ -536,7 +536,7 @@ class TestLlmClient:
         client = LlmClient()
         _parsed, errors = client._parse_llm_json_response(
             "{not json}",
-            {"corrupted": bool},
+            {"corrupted": [bool]},
         )
         assert "Failed to parse LLM response" in errors
 

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -685,7 +685,7 @@ class TestLlmClient:
         )
 
     @pytest.mark.asyncio
-    async def test_get_single_gui_action_returns_normalized_click_action(self):
+    async def test_get_single_gui_action_returns_click_action(self):
         client = LlmClient()
         image = Image.new("RGB", (10, 10))
 
@@ -724,7 +724,7 @@ class TestLlmClient:
         assert action == {
             "action_type": "Write",
             "text": "hello",
-            "point_2d": [-100.0, -100.0],
+            "point_2d": [-100, -100],
         }
 
     @pytest.mark.asyncio

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -193,6 +193,12 @@ class TestLlmClient:
 
     OBJECT_FOUND_RESPONSE = json.dumps({"point_2d": [250, 500]})
     OBJECT_NOT_FOUND_RESPONSE = json.dumps({"point_2d": [-100, -100]})
+    STATE_MATCH_RESPONSE = json.dumps(
+        {"matches_description": True, "reasoning": "state is present"}
+    )
+    STATE_MISMATCH_RESPONSE = json.dumps(
+        {"matches_description": False, "reasoning": "state is absent"}
+    )
 
     @pytest.mark.asyncio
     async def test_valid_response(self, mock_post):
@@ -576,4 +582,89 @@ class TestLlmClient:
         mock_log_image.assert_called_once_with(
             annotated,
             "LLM indicated point for: the OK button",
+        )
+
+    @pytest.mark.asyncio
+    async def test_assert_state_passes_when_state_matches(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch.object(
+            client,
+            "prompt_llm",
+            return_value=self.STATE_MATCH_RESPONSE,
+        ) as mock_prompt:
+            result = await client.assert_state("desktop is visible", image)
+
+        assert result is None
+        mock_prompt.assert_called_once()
+        assert mock_prompt.call_args.kwargs["image"] is image
+        assert mock_prompt.call_args.kwargs["prompt"] == (
+            "Check if this state is present on the screen: desktop is visible"
+        )
+
+    @pytest.mark.asyncio
+    async def test_assert_state_raises_when_state_does_not_match(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.STATE_MISMATCH_RESPONSE,
+            ),
+            pytest.raises(
+                AssertionError,
+                match=(
+                    "State does NOT match description: desktop is visible. "
+                    "Reasoning: state is absent"
+                ),
+            ),
+        ):
+            await client.assert_state("desktop is visible", image)
+
+    @pytest.mark.asyncio
+    async def test_assert_state_grabs_screenshot_when_no_image(self):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.STATE_MATCH_RESPONSE,
+            ) as mock_prompt,
+        ):
+            await client.assert_state("desktop is visible")
+
+        assert mock_prompt.call_args.kwargs["image"] is screenshot
+        mock_video.grab_screenshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_assert_state_uses_custom_system_prompt(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch.object(
+            client,
+            "prompt_llm",
+            return_value=self.STATE_MATCH_RESPONSE,
+        ) as mock_prompt:
+            await client.assert_state(
+                "desktop is visible",
+                image,
+                custom_system_prompt="Only answer JSON.",
+            )
+
+        assert mock_prompt.call_args.kwargs["system_prompt"] == (
+            "Only answer JSON."
         )

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -172,9 +172,10 @@ class TestLlmClient:
             )
             result = client._get_lib_instance("VideoInput")
 
-        mock_builtin_cls.return_value.get_library_instance.assert_called_once_with(
-            "VideoInput"
+        get_library_instance = (
+            mock_builtin_cls.return_value.get_library_instance
         )
+        get_library_instance.assert_called_once_with("VideoInput")
         assert result is sentinel
 
     VALID_RESPONSE = json.dumps(
@@ -198,6 +199,20 @@ class TestLlmClient:
     )
     STATE_MISMATCH_RESPONSE = json.dumps(
         {"matches_description": False, "reasoning": "state is absent"}
+    )
+    CLICK_ACTION_RESPONSE = json.dumps(
+        {
+            "action_type": "Left Click",
+            "text": None,
+            "point_2d": [250, 500],
+        }
+    )
+    WRITE_ACTION_RESPONSE = json.dumps(
+        {
+            "action_type": "Write",
+            "text": "hello",
+            "point_2d": [-100, -100],
+        }
     )
 
     @pytest.mark.asyncio
@@ -668,3 +683,176 @@ class TestLlmClient:
         assert mock_prompt.call_args.kwargs["system_prompt"] == (
             "Only answer JSON."
         )
+
+    @pytest.mark.asyncio
+    async def test_get_single_gui_action_returns_normalized_click_action(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch(f"{self.LLM_PATH}.log_image"),
+            patch(f"{self.LLM_PATH}.draw_point_on_image"),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.CLICK_ACTION_RESPONSE,
+            ) as mock_prompt,
+        ):
+            action = await client.get_single_gui_action("click OK", image)
+
+        assert action == {
+            "action_type": "Left Click",
+            "text": None,
+            "point_2d": [250, 500],
+        }
+        mock_prompt.assert_called_once()
+        assert mock_prompt.call_args.kwargs["image"] is image
+        assert mock_prompt.call_args.kwargs["prompt"] == "click OK"
+
+    @pytest.mark.asyncio
+    async def test_get_single_gui_action_returns_write_action(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch.object(
+            client,
+            "prompt_llm",
+            return_value=self.WRITE_ACTION_RESPONSE,
+        ):
+            action = await client.get_single_gui_action("type hello", image)
+
+        assert action == {
+            "action_type": "Write",
+            "text": "hello",
+            "point_2d": [-100.0, -100.0],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_single_gui_action_grabs_screenshot_when_no_image(self):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.CLICK_ACTION_RESPONSE,
+            ) as mock_prompt,
+        ):
+            action = await client.get_single_gui_action("click OK")
+
+        assert action["point_2d"] == [250, 500]
+        assert mock_prompt.call_args.kwargs["image"] is screenshot
+        mock_video.grab_screenshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_single_gui_action_rejects_unsupported_action(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+        response = json.dumps(
+            {"action_type": "Wait", "text": None, "point_2d": [-100, -100]}
+        )
+
+        with (
+            patch.object(client, "prompt_llm", return_value=response),
+            pytest.raises(ValueError, match="Unsupported GUI action: Wait"),
+        ):
+            await client.get_single_gui_action("wait", image)
+
+    @pytest.mark.asyncio
+    async def test_execute_gui_action_left_click_uses_normalized_point(self):
+        client = LlmClient()
+        mock_hid = MagicMock()
+        mock_hid.move_pointer_to_proportional = AsyncMock()
+        mock_hid.click_pointer_button = AsyncMock()
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(
+            return_value=Image.new("RGB", (10, 10))
+        )
+
+        def get_library(name):
+            return {"HID": mock_hid, "VideoInput": mock_video}[name]
+
+        with patch.object(
+            client, "_get_lib_instance", side_effect=get_library
+        ):
+            await client.execute_gui_action(
+                {
+                    "action_type": "Left Click",
+                    "text": None,
+                    "point_2d": [250, 500],
+                }
+            )
+
+        mock_hid.move_pointer_to_proportional.assert_awaited_once_with(
+            0.25, 0.5
+        )
+        mock_hid.click_pointer_button.assert_awaited_once_with("LEFT")
+        mock_video.grab_screenshot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_gui_action_accepts_legacy_grid_point(self):
+        client = LlmClient()
+        mock_hid = MagicMock()
+        mock_hid.move_pointer_to_proportional = AsyncMock()
+        mock_hid.click_pointer_button = AsyncMock()
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(
+            return_value=Image.new("RGB", (10, 10))
+        )
+
+        def get_library(name):
+            return {"HID": mock_hid, "VideoInput": mock_video}[name]
+
+        with patch.object(
+            client, "_get_lib_instance", side_effect=get_library
+        ):
+            await client.execute_gui_action(
+                {
+                    "action_type": "Right Click",
+                    "text": None,
+                    "point_2d": [250, 500],
+                }
+            )
+
+        mock_hid.move_pointer_to_proportional.assert_awaited_once_with(
+            0.25, 0.5
+        )
+        mock_hid.click_pointer_button.assert_awaited_once_with("RIGHT")
+
+    @pytest.mark.asyncio
+    async def test_execute_gui_action_writes_text(self):
+        client = LlmClient()
+        mock_hid = MagicMock()
+        mock_hid.type_string = AsyncMock()
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(
+            return_value=Image.new("RGB", (10, 10))
+        )
+
+        def get_library(name):
+            return {"HID": mock_hid, "VideoInput": mock_video}[name]
+
+        with patch.object(
+            client, "_get_lib_instance", side_effect=get_library
+        ):
+            await client.execute_gui_action(
+                {
+                    "action_type": "Write",
+                    "text": "hello",
+                    "point_2d": [-100, -100],
+                }
+            )
+
+        mock_hid.type_string.assert_awaited_once_with("hello")

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image
 
-from yarf.errors.yarf_errors import VQAValidationError, VQADetectionError
+from yarf.errors.yarf_errors import VQADetectionError, VQAValidationError
 from yarf.rf_libraries.libraries.llm_client.LlmClient import LlmClient
 
 

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -23,6 +23,8 @@ def mock_logger():
 
 
 class TestLlmClient:
+    LLM_PATH = "yarf.rf_libraries.libraries.llm_client.LlmClient"
+
     def _mock_response(
         self, content: str = "ok", reasoning: str | None = None
     ) -> MagicMock:
@@ -188,6 +190,9 @@ class TestLlmClient:
             "description": "noise in top-left corner",
         }
     )
+
+    OBJECT_FOUND_RESPONSE = json.dumps({"point_2d": [250, 500]})
+    OBJECT_NOT_FOUND_RESPONSE = json.dumps({"point_2d": [-100, -100]})
 
     @pytest.mark.asyncio
     async def test_valid_response(self, mock_post):
@@ -475,3 +480,100 @@ class TestLlmClient:
             {"corrupted": bool},
         )
         assert "Failed to parse LLM response" in errors
+
+    @pytest.mark.asyncio
+    @patch(f"{LLM_PATH}.log_image", MagicMock())
+    @patch(f"{LLM_PATH}.draw_point_on_image", MagicMock())
+    async def test_get_object_position_returns_point(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with patch.object(
+            client,
+            "prompt_llm",
+            return_value=self.OBJECT_FOUND_RESPONSE,
+        ) as mock_prompt:
+            point = await client.get_object_position("the OK button", image)
+
+        assert point == [0.25, 0.5]
+        mock_prompt.assert_called_once()
+        assert mock_prompt.call_args.kwargs["image"] is image
+        assert mock_prompt.call_args.kwargs["prompt"] == (
+            "Find the position of this object: the OK button"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_object_position_raises_when_object_not_found(self):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.OBJECT_NOT_FOUND_RESPONSE,
+            ),
+            pytest.raises(
+                VQAValidationError,
+                match="Object was not found: missing thing",
+            ),
+        ):
+            await client.get_object_position("missing thing", image)
+
+    @pytest.mark.asyncio
+    async def test_get_object_position_grabs_screenshot_when_no_image(self):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.OBJECT_FOUND_RESPONSE,
+            ) as mock_prompt,
+        ):
+            point = await client.get_object_position("the OK button")
+
+        assert point == [0.25, 0.5]
+        assert mock_prompt.call_args.kwargs["image"] is screenshot
+        mock_video.grab_screenshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{LLM_PATH}.log_image")
+    @patch(f"{LLM_PATH}.draw_point_on_image")
+    async def test_get_object_position_logs_point_in_debug_mode(
+        self, mock_draw_image, mock_log_image
+    ):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+        annotated = Image.new("RGB", (10, 10))
+
+        mock_draw_image.return_value = annotated
+        with (
+            patch.dict("os.environ", {"YARF_LOG_LEVEL": "DEBUG"}),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.OBJECT_FOUND_RESPONSE,
+            ),
+        ):
+            point = await client.get_object_position("the OK button", image)
+
+        assert point == [0.25, 0.5]
+        mock_draw_image.assert_called_once_with(
+            image,
+            [0.25, 0.5],
+            label="the OK button",
+        )
+        mock_log_image.assert_called_once_with(
+            annotated,
+            "LLM indicated point for: the OK button",
+        )

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -178,6 +178,41 @@ class TestLlmClient:
         get_library_instance.assert_called_once_with("VideoInput")
         assert result is sentinel
 
+    @pytest.mark.asyncio
+    async def test_grab_screenshot(self):
+        client = LlmClient()
+        screenshot = Image.new("RGB", (10, 10))
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
+
+        with patch.object(
+            client,
+            "_get_lib_instance",
+            return_value=mock_video,
+        ):
+            result = await client._grab_screenshot()
+
+        assert result is screenshot
+        mock_video.grab_screenshot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_grab_screenshot_raises_when_screenshot_fails(self):
+        client = LlmClient()
+
+        mock_video = MagicMock()
+        mock_video.grab_screenshot = AsyncMock(return_value=None)
+
+        with (
+            patch.object(
+                client,
+                "_get_lib_instance",
+                return_value=mock_video,
+            ),
+            pytest.raises(RuntimeError, match="Failed to grab screenshot"),
+        ):
+            await client._grab_screenshot()
+
     VALID_RESPONSE = json.dumps(
         {
             "corrupted": False,
@@ -267,12 +302,13 @@ class TestLlmClient:
         client = LlmClient()
         screenshot = Image.new("RGB", (10, 10))
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
-
         # LLM returns valid response for grabbed screenshot
         with (
-            patch.object(client, "_get_lib_instance", return_value=mock_video),
+            patch.object(
+                client,
+                "_grab_screenshot",
+                AsyncMock(return_value=screenshot),
+            ) as mock_grab,
             patch.object(
                 client, "prompt_llm", return_value=self.VALID_RESPONSE
             ),
@@ -280,18 +316,20 @@ class TestLlmClient:
             result = await client.check_for_visual_corruption()
 
         assert result["corrupted"] is False
-        mock_video.grab_screenshot.assert_awaited_once()
+        mock_grab.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_raises_when_screenshot_fails(self, mock_post):
         client = LlmClient()
-
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(return_value=None)
+        exc = RuntimeError("Failed to grab screenshot")
 
         # LLM check raises error when screenshot cannot be grabbed
         with (
-            patch.object(client, "_get_lib_instance", return_value=mock_video),
+            patch.object(
+                client,
+                "_grab_screenshot",
+                AsyncMock(side_effect=exc),
+            ),
             pytest.raises(RuntimeError, match="Failed to grab screenshot"),
         ):
             await client.check_for_visual_corruption()
@@ -546,15 +584,12 @@ class TestLlmClient:
         client = LlmClient()
         screenshot = Image.new("RGB", (10, 10))
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
-
         with (
             patch.object(
                 client,
-                "_get_lib_instance",
-                return_value=mock_video,
-            ),
+                "_grab_screenshot",
+                AsyncMock(return_value=screenshot),
+            ) as mock_grab,
             patch.object(
                 client,
                 "prompt_llm",
@@ -565,7 +600,22 @@ class TestLlmClient:
 
         assert point == [0.25, 0.5]
         assert mock_prompt.call_args.kwargs["image"] is screenshot
-        mock_video.grab_screenshot.assert_awaited_once()
+        mock_grab.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_object_position_raises_when_screenshot_fails(self):
+        client = LlmClient()
+        exc = RuntimeError("Failed to grab screenshot")
+
+        with (
+            patch.object(
+                client,
+                "_grab_screenshot",
+                AsyncMock(side_effect=exc),
+            ),
+            pytest.raises(RuntimeError, match="Failed to grab screenshot"),
+        ):
+            await client.get_object_position("the OK button")
 
     @pytest.mark.asyncio
     @patch(f"{LLM_PATH}.log_image")
@@ -644,15 +694,12 @@ class TestLlmClient:
         client = LlmClient()
         screenshot = Image.new("RGB", (10, 10))
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
-
         with (
             patch.object(
                 client,
-                "_get_lib_instance",
-                return_value=mock_video,
-            ),
+                "_grab_screenshot",
+                AsyncMock(return_value=screenshot),
+            ) as mock_grab,
             patch.object(
                 client,
                 "prompt_llm",
@@ -662,7 +709,22 @@ class TestLlmClient:
             await client.assert_state("desktop is visible")
 
         assert mock_prompt.call_args.kwargs["image"] is screenshot
-        mock_video.grab_screenshot.assert_awaited_once()
+        mock_grab.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_assert_state_raises_when_screenshot_fails(self):
+        client = LlmClient()
+        exc = RuntimeError("Failed to grab screenshot")
+
+        with (
+            patch.object(
+                client,
+                "_grab_screenshot",
+                AsyncMock(side_effect=exc),
+            ),
+            pytest.raises(RuntimeError, match="Failed to grab screenshot"),
+        ):
+            await client.assert_state("desktop is visible")
 
     @pytest.mark.asyncio
     async def test_assert_state_uses_custom_system_prompt(self):
@@ -732,15 +794,12 @@ class TestLlmClient:
         client = LlmClient()
         screenshot = Image.new("RGB", (10, 10))
 
-        mock_video = MagicMock()
-        mock_video.grab_screenshot = AsyncMock(return_value=screenshot)
-
         with (
             patch.object(
                 client,
-                "_get_lib_instance",
-                return_value=mock_video,
-            ),
+                "_grab_screenshot",
+                AsyncMock(return_value=screenshot),
+            ) as mock_grab,
             patch.object(
                 client,
                 "prompt_llm",
@@ -751,7 +810,30 @@ class TestLlmClient:
 
         assert action["point_2d"] == [250, 500]
         assert mock_prompt.call_args.kwargs["image"] is screenshot
-        mock_video.grab_screenshot.assert_awaited_once()
+        mock_grab.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{LLM_PATH}.log_image")
+    async def test_get_single_gui_action_logs_screenshot_in_debug(
+        self, mock_log_image
+    ):
+        client = LlmClient()
+        image = Image.new("RGB", (10, 10))
+
+        with (
+            patch.dict("os.environ", {"YARF_LOG_LEVEL": "DEBUG"}),
+            patch.object(
+                client,
+                "prompt_llm",
+                return_value=self.WRITE_ACTION_RESPONSE,
+            ),
+        ):
+            await client.get_single_gui_action("type hello", image)
+
+        mock_log_image.assert_called_once_with(
+            image,
+            msg="Screenshot provided to LLM for GUI action decision",
+        )
 
     @pytest.mark.asyncio
     async def test_get_single_gui_action_rejects_unsupported_action(self):


### PR DESCRIPTION
<!--
Example Title: [BugFix] Fixed bugged behaviour of YARF load config

Pick one of the following:
- Infra: Your change only includes documentation, comments or github actions
- BugFix: Your change fixes a bug
- New: Your change is a new backward compatible feature, a new test/test plan/test inclusion
- Breaking: Your change breaks backward compatibility

Signed commits are required.

The default merge method of this repository is Squash and Merge, please add a comment if Merge Commit is preferred.
-->

## Description

<!--
Describe your changes here:

- What's the problem solved (briefly, since the issue is where this is elaborated in more detail).
- Introduce your implementation approach in a way that helps reviewing it well.
- Alert the reviewer of any changes that involve data persistence: present examples of file format changes as part of the PR description (e.g. new fields of data stored in unit or submission output).
-->

Adds LLM-driven GUI navigation helpers to LlmClient and improves JSON response validation for LLM-based visual checks. This branch introduces keywords for locating UI objects, asserting screen state, choosing a single GUI action, and executing that action through the active HID library.

Changes

 - Added robust LLM JSON validation with automatic correction retry for malformed or schema-invalid responses.
 - Split JSON parsing/validation into _parse_llm_json_response and async _verify_llm_json_response.
 - Added Get Object Position keyword
 - Added Assert State keyword
 - Added Get Single Gui Action keyword. Supports click, right-click, double-click, and write actions.
 - Added Execute Gui Action keyword. Supports click, right-click, double-click, and write actions.
 - Added image utility helpers for point normalization and debug point annotation.

## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->

https://warthogs.atlassian.net/browse/ZAP-1438

## Documentation

<!--
Please make sure that...
- Documentation impacted by the changes is up to date (becomes so, remains so).
  - Documentation in the repository, including contribution guidelines.
  - Process documentation outside the repository.
- Tests are included for the changed functionality in this PR. If to be merged without tests, please elaborate why.
- When breaking changes and other key changes are introduced, the PR having been merged should be broadcast (in demo sessions, IM, Discourse) with relevant references to documentation. This is an opportunity to gather feedback and confirm that the changes and how they are documented are understood.
-->

Inline docs have been added and  the yarf documentation now includes GUI navigation keywords

## Tests

<!--
- How was this PR tested? Please provide steps to follow so that the reviewer(s) can test on their end.
- Please provide a list of what tests were run and on what platform/configuration.
- Remember to check the test coverage of your PR as described in CONTRIBUTING.md
-->

Unit tests added


Small robot framework test:

```robotframework
*** Settings ***
Library     yarf/rf_libraries/libraries/llm_client/LlmClient.py
Resource    kvm.resource


*** Test Cases ***

Test 

    Configure Llm Client    server_url=https://jetson-orin.tail4cb40c.ts.net/
    ...    model=qwen3.5:4b
    
    
    ${position} =  Get Object Position    description=Nautilus icon on the launcher
    Log     Position of Nautilus icon: ${position}

    ${action} =    Get single gui action    task= Click on the Nautilus icon on the launcher    image=${None}
    Execute Gui Action     ${action}

    Assert State    description=The file explorer is open

```

Yarf log: 
[log.html](https://github.com/user-attachments/files/27217398/log.html)


