### PR TITLE
[BugFix] Avoid high CPU usage while trying to match images

### DIFF
--- a/yarf/rf_libraries/libraries/tests/test_video_input_base.py
+++ b/yarf/rf_libraries/libraries/tests/test_video_input_base.py
@@ -60,9 +60,12 @@ def stub_videoinput(request):
 
 @pytest.fixture(autouse=True)
 def mock_time():
-    with patch("time.time") as p:
-        p.return_value = 0
-        yield p
+    mock = Mock(return_value=0)
+    mock_time_module = Mock(time=mock, monotonic=mock)
+    with patch(
+        "yarf.rf_libraries.libraries.video_input_base.time", mock_time_module
+    ):
+        yield mock
 
 
 @pytest.fixture(autouse=True)
@@ -124,6 +127,27 @@ class TestVideoInputBase:
         ]
         assert await stub_videoinput.match("path") == expected
         stub_videoinput.grab_screenshot.return_value.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "yarf.rf_libraries.libraries.video_input_base.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+    async def test_match_waits_for_minimum_iteration_time(
+        self, mock_sleep, stub_videoinput, mock_time
+    ):
+        stub_videoinput.grab_screenshot.side_effect = [
+            RuntimeError,
+            stub_videoinput.grab_screenshot.return_value,
+        ]
+        stub_videoinput._rpa_images.find_template_in_image.return_value = [
+            Mock()
+        ]
+        mock_time.side_effect = [0, 0.02, 0.05, 0.12]
+
+        await stub_videoinput.match("path", timeout=1)
+
+        assert mock_sleep.await_args.args[0] == pytest.approx(0.07)
 
     @pytest.mark.asyncio
     @pytest.mark.start_suite
@@ -297,7 +321,7 @@ class TestVideoInputBase:
         stub_videoinput._rpa_images.find_template_in_image.side_effect = (
             ValueError
         )
-        mock_time.side_effect = [0, 0, 2]
+        mock_time.side_effect = [0, 0, 2, 2]
 
         with pytest.raises(ImageNotFoundError):
             await stub_videoinput.match("path", timeout=1)
@@ -309,7 +333,7 @@ class TestVideoInputBase:
         stub_videoinput._rpa_images.find_template_in_image.side_effect = (
             ImageNotFoundError
         )
-        mock_time.side_effect = [0, 0, 2]
+        mock_time.side_effect = [0, 0, 2, 2]
 
         with pytest.raises(ImageNotFoundError):
             await stub_videoinput.match("path", timeout=1)
@@ -330,10 +354,14 @@ class TestVideoInputBase:
         stub_videoinput._rpa_images.find_template_in_image.side_effect = (
             ImageNotFoundError
         )
-        mock_time.side_effect = [0, 0, 0, 2]
+        mock_time.side_effect = [0, 0, 0.05, 0.5, 2, 2]
 
-        with pytest.raises(ImageNotFoundError):
-            await stub_videoinput.match("path", timeout=1)
+        with patch(
+            "yarf.rf_libraries.libraries.video_input_base.asyncio.sleep",
+            new=AsyncMock(),
+        ):
+            with pytest.raises(ImageNotFoundError):
+                await stub_videoinput.match("path", timeout=1)
 
         assert (
             stub_videoinput.grab_screenshot.return_value.save.call_args_list
@@ -373,7 +401,7 @@ class TestVideoInputBase:
         stub_videoinput._rpa_images.find_template_in_image.side_effect = (
             ImageNotFoundError
         )
-        mock_time.side_effect = [0, 0, 2]
+        mock_time.side_effect = [0, 0, 2, 2]
 
         with pytest.raises(ImageNotFoundError):
             await stub_videoinput.match("path", timeout=1)
@@ -397,10 +425,14 @@ class TestVideoInputBase:
             stub_videoinput._rpa_images.find_template_in_image.side_effect = (
                 ImageNotFoundError
             )
-            mock_time.side_effect = [0, 0, 0, 2]
+            mock_time.side_effect = [0, 0, 0.05, 0.5, 2, 2]
 
-            with pytest.raises(ImageNotFoundError):
-                await stub_videoinput.match("path", timeout=1)
+            with patch(
+                "yarf.rf_libraries.libraries.video_input_base.asyncio.sleep",
+                new=AsyncMock(),
+            ):
+                with pytest.raises(ImageNotFoundError):
+                    await stub_videoinput.match("path", timeout=1)
 
             # Screenshots should still be saved
             save_calls = stub_videoinput.grab_screenshot.return_value.save.call_args_list
@@ -656,6 +688,25 @@ class TestVideoInputBase:
         assert await stub_videoinput.match_text("Hello") == (result, image)
 
     @pytest.mark.asyncio
+    @patch(
+        "yarf.rf_libraries.libraries.video_input_base.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+    async def test_match_text_waits_for_minimum_iteration_time(
+        self, mock_sleep, stub_videoinput, mock_time
+    ):
+        image = AsyncMock()
+        result = [
+            {"text": "Hello", "region": Region(0, 0, 1, 1), "confidence": 0.9},
+        ]
+        mock_time.side_effect = [0, 0.02, 0.05, 0.12]
+        stub_videoinput.find_text = AsyncMock(side_effect=[[], result])
+        stub_videoinput.grab_screenshot.return_value = image
+
+        assert await stub_videoinput.match_text("Hello") == (result, image)
+        assert mock_sleep.await_args.args[0] == pytest.approx(0.07)
+
+    @pytest.mark.asyncio
     async def test_match_text_with_color_succeeds(
         self, stub_videoinput, mock_time
     ):
@@ -781,6 +832,21 @@ class TestVideoInputBase:
         stub_videoinput.read_text.return_value = "wrong\ntext"
         with pytest.raises(Exception) as e:
             await stub_videoinput.match_text("hello")
+
+        mock_log_image.assert_called()
+        assert "Timed out looking for 'hello'" in str(e.value)
+        assert "Text read on screen was:\nwrong\ntext" in str(e.value)
+
+    @pytest.mark.asyncio
+    @patch("yarf.rf_libraries.libraries.video_input_base.log_image")
+    async def test_match_text_fails_with_zero_timeout(
+        self, mock_log_image, stub_videoinput
+    ):
+        stub_videoinput.find_text = AsyncMock(return_value=[])
+        stub_videoinput.read_text = AsyncMock(return_value="wrong\ntext")
+
+        with pytest.raises(Exception) as e:
+            await stub_videoinput.match_text("hello", timeout=0)
 
         mock_log_image.assert_called()
         assert "Timed out looking for 'hello'" in str(e.value)
@@ -1128,7 +1194,7 @@ class TestVideoInputBase:
         mock_log_image.assert_called_once_with(screenshot, "Debug message")
 
     @pytest.mark.asyncio
-    @patch("time.monotonic")
+    @patch("yarf.rf_libraries.libraries.video_input_base.time.monotonic")
     async def test_wait_still_screen(
         self, mock_monotonic_time, stub_videoinput, mock_logger
     ):
@@ -1152,7 +1218,7 @@ class TestVideoInputBase:
         stub_videoinput.grab_screenshot = AsyncMock(side_effect=screenshots)
 
         mock_monotonic_time.side_effect = [0, 0, 0, 1, 1, 1, 2, 3]
-        with patch("time.sleep"):
+        with patch("yarf.rf_libraries.libraries.video_input_base.time.sleep"):
             await stub_videoinput.wait_still_screen(
                 duration=5, still_duration=2, screenshot_interval=1
             )
@@ -1162,7 +1228,7 @@ class TestVideoInputBase:
         )
 
     @pytest.mark.asyncio
-    @patch("time.monotonic")
+    @patch("yarf.rf_libraries.libraries.video_input_base.time.monotonic")
     async def test_wait_still_screen_timeout(
         self, mock_monotonic_time, stub_videoinput
     ):
@@ -1212,7 +1278,10 @@ class TestVideoInputBase:
             5,
             5,
         ]
-        with patch("time.sleep"), pytest.raises(TimeoutError) as e:
+        with (
+            patch("yarf.rf_libraries.libraries.video_input_base.time.sleep"),
+            pytest.raises(TimeoutError) as e,
+        ):
             await stub_videoinput.wait_still_screen(
                 duration=5, still_duration=2, screenshot_interval=1
             )

--- a/yarf/rf_libraries/libraries/video_input_base.py
+++ b/yarf/rf_libraries/libraries/video_input_base.py
@@ -41,6 +41,7 @@ from yarf.vendor.RPA.recognition.templates import ImageNotFoundError
 DISPLAY_PATTERN = r"((?P<id>[\w-]+)\:)?(?P<resolution>\d+x\d+)(\s+|$)"
 DISPLAY_RE = re.compile(rf"{DISPLAY_PATTERN}")
 DISPLAYS_RE = re.compile(rf"^({DISPLAY_PATTERN})+$")
+MIN_MATCH_ITERATION_TIME = 0.1
 
 
 class VideoInputBase(ABC):
@@ -436,8 +437,16 @@ class VideoInputBase(ABC):
         region = to_region(region)
         print(f"\nLooking for '{text}'")
         print(region)
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        start_time = time.monotonic()
+        first_iteration = True
+        while True:
+            iteration_start_time = time.monotonic()
+            if (
+                not first_iteration
+                and iteration_start_time - start_time >= timeout
+            ):
+                break
+            first_iteration = False
             image = await self._grab_and_save_screenshot()
             # Save the cropped image for debugging
             cropped_image = (
@@ -464,6 +473,9 @@ class VideoInputBase(ABC):
 
             if text_matches:
                 return text_matches, cropped_image
+            await self._sleep_for_minimum_iteration_time(
+                iteration_start_time, start_time + timeout
+            )
 
         read_text = await self.read_text(cropped_image)
 
@@ -608,6 +620,31 @@ class VideoInputBase(ABC):
 
         return screenshot
 
+    async def _sleep_for_minimum_iteration_time(
+        self, iteration_start_time: float, end_time: float | None = None
+    ) -> None:
+        """
+        Pause between image-matching iterations to avoid busy-waiting.
+
+        Matching can otherwise repeatedly capture and inspect frames
+        without pausing when each operation completes quickly,
+        unnecessarily consuming CPU. Awaiting the delay gives the asyncio
+        event loop an opportunity to run other tasks. Sleep only for the
+        remaining portion of the minimum iteration time, and do not sleep
+        beyond the matching deadline when one is given.
+
+        Args:
+            iteration_start_time: Monotonic time when the iteration began.
+            end_time: Optional monotonic deadline for the matching operation.
+        """
+        current_time = time.monotonic()
+        elapsed = current_time - iteration_start_time
+        sleep_time = max(0.0, MIN_MATCH_ITERATION_TIME - elapsed)
+        if end_time is not None:
+            sleep_time = min(sleep_time, max(0.0, end_time - current_time))
+        if sleep_time > 0:
+            await asyncio.sleep(sleep_time)
+
     async def _do_match(
         self,
         templates: Sequence[str],
@@ -646,13 +683,17 @@ class VideoInputBase(ABC):
             )
             for template, image in template_images.items()
         }
-        end_time = time.time() + float(timeout)
-        while (now := time.time()) < end_time:
+        end_time = time.monotonic() + float(timeout)
+        while (iteration_start_time := time.monotonic()) < end_time:
             try:
                 screenshot = await asyncio.wait_for(
-                    self._grab_and_save_screenshot(), end_time - now
+                    self._grab_and_save_screenshot(),
+                    end_time - iteration_start_time,
                 )
             except RuntimeError:
+                await self._sleep_for_minimum_iteration_time(
+                    iteration_start_time, end_time
+                )
                 continue
             matches = []
             for path, image in template_images.items():
@@ -695,6 +736,9 @@ class VideoInputBase(ABC):
                 # have matched
                 if not accept_any:
                     return matches
+            await self._sleep_for_minimum_iteration_time(
+                iteration_start_time, end_time
+            )
 
         if screenshot:
             for template in templates:


### PR DESCRIPTION
Leave some CPU cycles for other processes by sleeping for up to 0.1 seconds during each loop iteration.
