### PR TITLE
[New] Support not logging video

### DIFF
--- a/docs/how-to/run-a-robot-test-suite-in-yarf.md
+++ b/docs/how-to/run-a-robot-test-suite-in-yarf.md
@@ -171,3 +171,13 @@ When any test fails, YARF adds two important features here:
 - For the whole suite, it will log a video with all screenshots taken leading up to the failure.
   You'll be able to see what went wrong _before_ the test failed and hopefully identify the problem
   directly from the log file, without having to look at the test run live.
+
+### Controlling video logging
+
+You can control when YARF logs videos using the `YARF_LOG_VIDEO` environment variable:
+
+- **Unset** (default): Log video only when tests fail
+- **`YARF_LOG_VIDEO=1`**: Always log video, even when tests succeed
+- **`YARF_LOG_VIDEO=0`**: Never log video, even when tests fail
+
+Alternatively, use the `--log-video` CLI flag to always log video (equivalent to `YARF_LOG_VIDEO=1`).

--- a/yarf/main.py
+++ b/yarf/main.py
@@ -145,7 +145,7 @@ def parse_yarf_arguments(argv: list[str]) -> Namespace:
     top_level_parser.add_argument(
         "--log-video",
         action="store_true",
-        help="Log video even if test succeeds - you can alternatively the YARF_LOG_VIDEO env variable to 1.",
+        help="Log video even if test succeeds. Alternatively, set YARF_LOG_VIDEO environment variable: '1' to always log video, '0' to never log video (even on failure), or unset for default behavior (log only on failure).",
     )
 
     top_level_parser.add_argument(

--- a/yarf/rf_libraries/libraries/tests/test_video_input_base.py
+++ b/yarf/rf_libraries/libraries/tests/test_video_input_base.py
@@ -377,6 +377,41 @@ class TestVideoInputBase:
         mock_logger.warn.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.start_suite
+    async def test_match_fail_does_not_log_video_when_disabled(
+        self, stub_videoinput, mock_time, mock_run
+    ):
+        """
+        Check that video is NOT logged on test failure when YARF_LOG_VIDEO=0.
+        """
+        with patch.dict(os.environ, {"YARF_LOG_VIDEO": "0"}):
+            stub_videoinput._log_failed_match = Mock()
+
+            stub_videoinput._rpa_images.find_template_in_image.side_effect = (
+                ImageNotFoundError
+            )
+            mock_time.side_effect = [0, 0, 0, 2]
+
+            with pytest.raises(ImageNotFoundError):
+                await stub_videoinput.match("path", timeout=1)
+
+            # Screenshots should still be saved
+            assert (
+                stub_videoinput.grab_screenshot.return_value.save.call_args_list
+                == [
+                    call(
+                        "sentinel.tempdir/0000000001.png", compress_level=ANY
+                    ),
+                    call(
+                        "sentinel.tempdir/0000000002.png", compress_level=ANY
+                    ),
+                ]
+            )
+            # But video should NOT be created when YARF_LOG_VIDEO=0
+            stub_videoinput._end_suite(None, Mock(passed=False))
+            mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_match_converts_to_rgb(self, mock_to_image, stub_videoinput):
         """
         Check the Match keyword accepts non-RGB images and converts them.

--- a/yarf/rf_libraries/libraries/video_input_base.py
+++ b/yarf/rf_libraries/libraries/video_input_base.py
@@ -72,7 +72,8 @@ class VideoInputBase(ABC):
         self._screenshots_dir = tempfile.TemporaryDirectory()
 
     def _end_suite(self, data, result) -> None:
-        if result.failed or os.environ.get("YARF_LOG_VIDEO") == "1":
+        log_video = os.environ.get("YARF_LOG_VIDEO")
+        if log_video == "1" or (result.failed and log_video != "0"):
             if self._frame_count > 0:
                 assert self._screenshots_dir
                 video_path = f"{self._screenshots_dir.name}/video.webm"


### PR DESCRIPTION
Do not log the video when YARF_LOG_VIDEO is set to 0.

The rationale is that in the authd e2e-tests, we record an actual video of the VM and add it to the Robot Framework log. The video logged by YARF is not needed in that case.
