### PR TITLE
[New] Use WebP format for images to reduce file size

### DIFF
--- a/tests/keyword_suite/llm_client_test.robot
+++ b/tests/keyword_suite/llm_client_test.robot
@@ -43,4 +43,4 @@ Default Server with image
     Should Contain          ${out}                  port 11434
     Should Contain          ${out}                  model qwen3-vl:2b-instruct
     Should Contain          ${out}                  This is my prompt
-    Should Contain          ${out}                  data:image/png;base64
+    Should Contain          ${out}                  data:image/webp;base64

--- a/yarf/lib/images/tests/test_utils.py
+++ b/yarf/lib/images/tests/test_utils.py
@@ -15,6 +15,20 @@ class TestUtils:
         image.convert.assert_called_with("RGB")
 
         converted_image = image.convert.return_value
+        converted_image.save.assert_called_with(
+            ANY, format="WEBP", quality=80, method=4
+        )
+
+    def test_to_base64_with_explicit_format(self):
+        """
+        Test the function passes through an explicit image format.
+        """
+        image = Mock()
+
+        to_base64(image, format="PNG")
+        image.convert.assert_called_with("RGB")
+
+        converted_image = image.convert.return_value
         converted_image.save.assert_called_with(ANY, format="PNG")
 
     def test_to_RGB(self):

--- a/yarf/lib/images/tests/test_utils.py
+++ b/yarf/lib/images/tests/test_utils.py
@@ -1,35 +1,30 @@
 from unittest.mock import ANY, Mock
 
+import pytest
+
 from yarf.lib.images.utils import to_base64, to_RGB
 from yarf.vendor.RPA.Images import RGB
 
 
 class TestUtils:
-    def test_to_base64(self):
+    @pytest.mark.parametrize(
+        ("image_format", "expected_save_kwargs"),
+        [
+            ("WEBP", {"format": "WEBP", "quality": 80, "method": 4}),
+            ("PNG", {"format": "PNG"}),
+        ],
+    )
+    def test_to_base64(self, image_format, expected_save_kwargs):
         """
         Test the function converts the image to base64.
         """
         image = Mock()
 
-        to_base64(image)
+        to_base64(image, format=image_format)
         image.convert.assert_called_with("RGB")
 
         converted_image = image.convert.return_value
-        converted_image.save.assert_called_with(
-            ANY, format="WEBP", quality=80, method=4
-        )
-
-    def test_to_base64_with_explicit_format(self):
-        """
-        Test the function passes through an explicit image format.
-        """
-        image = Mock()
-
-        to_base64(image, format="PNG")
-        image.convert.assert_called_with("RGB")
-
-        converted_image = image.convert.return_value
-        converted_image.save.assert_called_with(ANY, format="PNG")
+        converted_image.save.assert_called_with(ANY, **expected_save_kwargs)
 
     def test_to_RGB(self):
         """

--- a/yarf/lib/images/utils.py
+++ b/yarf/lib/images/utils.py
@@ -11,12 +11,13 @@ from PIL import Image
 from yarf.vendor.RPA.Images import RGB
 
 
-def to_base64(image: Image.Image) -> str:
+def to_base64(image: Image.Image, format: str = "WEBP") -> str:
     """
     Convert Pillow Image to b64.
 
     Args:
         image: Image to convert
+        format: Image format to use (default: WEBP for smaller file size)
 
     Returns:
         Image as base64 string
@@ -24,7 +25,10 @@ def to_base64(image: Image.Image) -> str:
 
     im_file = BytesIO()
     image = image.convert("RGB")
-    image.save(im_file, format="PNG")
+    save_kwargs: dict[str, Any] = {"format": format}
+    if format.upper() == "WEBP":
+        save_kwargs.update({"quality": 80, "method": 4})
+    image.save(im_file, **save_kwargs)
     im_bytes = im_file.getvalue()  # im_bytes: image in binary format.
     im_b64 = base64.b64encode(im_bytes)
     return im_b64.decode()

--- a/yarf/rf_libraries/libraries/image/tests/test_utils.py
+++ b/yarf/rf_libraries/libraries/image/tests/test_utils.py
@@ -24,7 +24,7 @@ class TestImageUtils:
         mock_to_image.return_value = image
         log_image(image, "Debug message")
 
-        mock_base_64.assert_called_once_with(image)
+        mock_base_64.assert_called_once_with(image, format="WEBP")
         mock_logger.info.assert_called_once_with(ANY, html=True)
         assert mock_logger.info.call_args.args[0].startswith("Debug message")
 

--- a/yarf/rf_libraries/libraries/image/utils.py
+++ b/yarf/rf_libraries/libraries/image/utils.py
@@ -22,8 +22,8 @@ def log_image(image: Image.Image | str, msg: str = "") -> None:
     pil_image = to_image(image)
     image_string = (
         f"{msg}<br />"
-        '<img style="max-width: 100%" src="data:image/png;base64,'
-        f'{to_base64(pil_image)}" />'
+        '<img style="max-width: 100%" src="data:image/webp;base64,'
+        f'{to_base64(pil_image, format="WEBP")}" />'
     )
     logger.info(image_string, html=True)
 

--- a/yarf/rf_libraries/libraries/llm_client/LlmClient.py
+++ b/yarf/rf_libraries/libraries/llm_client/LlmClient.py
@@ -156,8 +156,8 @@ class LlmClient:
             The base64 encoded image string.
         """
 
-        b64 = to_base64(image)
-        return f"data:image/png;base64,{b64}"
+        b64 = to_base64(image, format="WEBP")
+        return f"data:image/webp;base64,{b64}"
 
     def _get_lib_instance(self, lib_name: str) -> Any:
         """

--- a/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
+++ b/yarf/rf_libraries/libraries/llm_client/tests/test_llm_client.py
@@ -139,7 +139,7 @@ class TestLlmClient:
         assert content[1]["type"] == "image_url"
 
         assert content[1]["image_url"]["url"].startswith(
-            "data:image/png;base64,"
+            "data:image/webp;base64,"
         )
 
     def test_prompt_with_reasoning(self, mock_post):
@@ -162,7 +162,7 @@ class TestLlmClient:
         mock_client = MagicMock()
         image = Image.new("RGB", (10, 10))
         encoded = LlmClient._encode_image(mock_client, image)
-        assert encoded.startswith("data:image/png;base64,")
+        assert encoded.startswith("data:image/webp;base64,")
 
     def test_get_lib_instance(self):
         client = LlmClient()


### PR DESCRIPTION
## Description

PNG screenshots at 1280x800 average ~460 KB each (base64-encoded: ~614 KB).  The same images as WebP at quality=80 average ~24 KB (base64-encoded: ~32 KB).

## Resolved issues

The log.html becomes huge for large test suites.

## Documentation

The image format was not documented as far as I can tell.

## Tests

We've been using this patch for some weeks/months now and didn't experience any issues.

Test cases were added.