### PR TITLE
[BugFix] Replace deprecated `asyncio.get_event_loop()` in check_connection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,8 @@ repos:
   rev: v8.2.4
   hooks:
   - id: robocop-format
+    additional_dependencies:
+    - click>=8.0.0
     args:
     - --select
     - RenameTestCases
@@ -81,6 +83,8 @@ repos:
     - --select
     - AlignTemplatedTestCases
   - id: robocop
+    additional_dependencies:
+    - click>=8.0.0
     args:
     - --select
     - NAME02

--- a/yarf/lib/wayland/tests/test_wayland_client.py
+++ b/yarf/lib/wayland/tests/test_wayland_client.py
@@ -46,7 +46,7 @@ class TestWaylandClient:
         stub_wc.display.attach_mock(mock_get_loop, "get_loop")
         stub_wc.display.attach_mock(stub_wc.connected, "connected")
 
-        with patch("asyncio.get_event_loop", mock_get_loop):
+        with patch("asyncio.get_running_loop", mock_get_loop):
             await stub_wc.connect()
 
         stub_wc.display.assert_has_calls(
@@ -73,7 +73,7 @@ class TestWaylandClient:
         stub_wc.disconnect = AsyncMock()
 
         with (
-            patch("asyncio.get_event_loop"),
+            patch("asyncio.get_running_loop"),
             pytest.raises(RuntimeError, match="DisplayFail"),
         ):
             await stub_wc.connect()
@@ -85,7 +85,7 @@ class TestWaylandClient:
         stub_wc.display.attach_mock(mock_get_loop, "get_loop")
         stub_wc.display.attach_mock(stub_wc.disconnected, "disconnected")
 
-        with patch("asyncio.get_event_loop", mock_get_loop):
+        with patch("asyncio.get_running_loop", mock_get_loop):
             await stub_wc.disconnect()
 
         stub_wc.display.assert_has_calls(
@@ -101,7 +101,7 @@ class TestWaylandClient:
     async def test_dispatch(self, stub_wc):
         mock_get_loop = Mock()
 
-        with patch("asyncio.get_event_loop", mock_get_loop):
+        with patch("asyncio.get_running_loop", mock_get_loop):
             await stub_wc.connect()
 
         mock_get_loop().add_writer.call_args.args[1]()
@@ -121,11 +121,11 @@ class TestWaylandClient:
         )
         mock_get_loop = Mock()
 
-        with patch("asyncio.get_event_loop", mock_get_loop):
+        with patch("asyncio.get_running_loop", mock_get_loop):
             await stub_wc.connect()
 
         with (
-            patch("asyncio.get_event_loop"),
+            patch("asyncio.get_running_loop"),
             pytest.raises(RuntimeError, match="DisplayFail"),
         ):
             mock_get_loop().add_writer.call_args.args[1]()

--- a/yarf/lib/wayland/wayland_client.py
+++ b/yarf/lib/wayland/wayland_client.py
@@ -36,7 +36,7 @@ class WaylandClient(ABC):
             self.display.dispatch(block=False)
         except Exception as e:
             _owasp_logger.sys_crash(f"Wayland dispatch error: {e}")
-            asyncio.get_event_loop().remove_writer(self.display.get_fd())
+            asyncio.get_running_loop().remove_writer(self.display.get_fd())
             raise e
 
     def timestamp(self) -> int:
@@ -105,7 +105,7 @@ class WaylandClient(ABC):
             registry.dispatcher["global"] = self.registry_global
             self.display.roundtrip()
             self.connected()
-            asyncio.get_event_loop().add_writer(
+            asyncio.get_running_loop().add_writer(
                 self.display.get_fd(), self._dispatch
             )
             return self
@@ -120,7 +120,7 @@ class WaylandClient(ABC):
         """
         Stop the connection to the compositor.
         """
-        asyncio.get_event_loop().remove_writer(self.display.get_fd())
+        asyncio.get_running_loop().remove_writer(self.display.get_fd())
         self.display.roundtrip()
         self.display.disconnect()
         self.disconnected()

--- a/yarf/rf_libraries/libraries/mir/Hid.py
+++ b/yarf/rf_libraries/libraries/mir/Hid.py
@@ -51,7 +51,7 @@ class Hid(HidBase):
             *_args: unused
         """
         if not self._connected:
-            asyncio.get_event_loop().run_until_complete(self._connect())
+            asyncio.run(self._connect())
 
     async def _keys_combo(self, combo: Sequence[str]) -> None:
         """
@@ -149,4 +149,4 @@ class Hid(HidBase):
         """
         Listener method called when the library goes out of scope.
         """
-        asyncio.get_event_loop().run_until_complete(self._disconnect())
+        asyncio.run(self._disconnect())

--- a/yarf/rf_libraries/libraries/mir/__init__.py
+++ b/yarf/rf_libraries/libraries/mir/__init__.py
@@ -13,6 +13,7 @@ from yarf.errors.yarf_errors import YARFConnectionError
 from yarf.lib.wayland import screencopy
 from yarf.lib.wayland.virtual_keyboard import VirtualKeyboard
 from yarf.lib.wayland.virtual_pointer import VirtualPointer
+from yarf.lib.wayland.wayland_client import WaylandClient
 from yarf.loggers.owasp_logger import get_owasp_logger
 from yarf.rf_libraries.libraries import PlatformBase
 
@@ -44,6 +45,10 @@ class Mir(PlatformBase):
         display_name = os.environ.get("WAYLAND_DISPLAY", "wayland-0")
 
         async def _async_connection_check():
+            """
+            Asynchronously check connection to the screen, pointer, and
+            keyboard.
+            """
             can_connect = False
             virtual_screen = screencopy.Screencopy(display_name)
             virtual_pointer = VirtualPointer(display_name)
@@ -56,7 +61,10 @@ class Mir(PlatformBase):
                 can_connect = True
             finally:
                 if can_connect:
-                    await virtual_screen.disconnect()
+                    # Screencopy.disconnect() is a no-op when no frame
+                    # has been captured; call WaylandClient.disconnect
+                    # directly to release the display resources.
+                    await WaylandClient.disconnect(virtual_screen)
                     await virtual_pointer.disconnect()
                     await virtual_keyboard.disconnect()
 

--- a/yarf/rf_libraries/libraries/mir/__init__.py
+++ b/yarf/rf_libraries/libraries/mir/__init__.py
@@ -26,6 +26,12 @@ class Mir(PlatformBase):
 
     @staticmethod
     def get_pkg_path() -> str:
+        """
+        Get the path to the Mir library package.
+
+        Returns:
+            str: The path to the Mir library package.
+        """
         return str(Path(__file__).parent)
 
     def check_connection(self) -> None:
@@ -55,15 +61,16 @@ class Mir(PlatformBase):
                     await virtual_keyboard.disconnect()
 
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(_async_connection_check())
+            else:
                 # If a loop is already running, we run the task and wait
                 future = asyncio.run_coroutine_threadsafe(
                     _async_connection_check(), loop
                 )
                 future.result()
-            else:
-                loop.run_until_complete(_async_connection_check())
             _owasp_logger.sys_monitor_enabled("system", "mir")
 
         except (ValueError, AssertionError, RuntimeError) as e:

--- a/yarf/rf_libraries/libraries/mir/tests/test_mir_init.py
+++ b/yarf/rf_libraries/libraries/mir/tests/test_mir_init.py
@@ -49,7 +49,7 @@ class TestMir:
                 new_callable=AsyncMock,
             ),
             patch(
-                "yarf.rf_libraries.libraries.mir.screencopy.Screencopy.disconnect",
+                "yarf.rf_libraries.libraries.mir.WaylandClient.disconnect",
                 new_callable=AsyncMock,
             ),
             patch(
@@ -88,7 +88,7 @@ class TestMir:
                 new_callable=AsyncMock,
             ),
             patch(
-                "yarf.rf_libraries.libraries.mir.screencopy.Screencopy.disconnect",
+                "yarf.rf_libraries.libraries.mir.WaylandClient.disconnect",
                 new_callable=AsyncMock,
             ),
             patch(

--- a/yarf/rf_libraries/libraries/mir/tests/test_mir_init.py
+++ b/yarf/rf_libraries/libraries/mir/tests/test_mir_init.py
@@ -71,9 +71,7 @@ class TestMir:
 
         mir = Mir()
         with (
-            patch(
-                "yarf.rf_libraries.libraries.mir.asyncio.get_event_loop"
-            ) as mock_get_event_loop,
+            patch("yarf.rf_libraries.libraries.mir.asyncio.get_running_loop"),
             patch(
                 "yarf.rf_libraries.libraries.mir.asyncio.run_coroutine_threadsafe"
             ),
@@ -102,5 +100,4 @@ class TestMir:
                 new_callable=AsyncMock,
             ),
         ):
-            mock_get_event_loop.return_value.is_running.return_value = True
             mir.check_connection()

--- a/yarf/rf_libraries/libraries/tests/test_video_input_base.py
+++ b/yarf/rf_libraries/libraries/tests/test_video_input_base.py
@@ -902,13 +902,11 @@ class TestVideoInputBase:
             (0, 0, 1, 1), outline="red", width=2
         )
 
-    @patch("asyncio.get_event_loop")
-    def test_close(self, mock_loop, stub_videoinput):
+    @patch("asyncio.run")
+    def test_close(self, mock_run, stub_videoinput):
         with patch.object(stub_videoinput, "stop_video_input", Mock()) as m:
             stub_videoinput._close()
-            mock_loop().run_until_complete.assert_called_once_with(
-                m.return_value
-            )
+            mock_run.assert_called_once_with(m.return_value)
 
     @pytest.mark.parametrize(
         "displays,expected",

--- a/yarf/rf_libraries/libraries/video_input_base.py
+++ b/yarf/rf_libraries/libraries/video_input_base.py
@@ -665,7 +665,7 @@ class VideoInputBase(ABC):
         """
         Listener method called when the library goes out of scope.
         """
-        asyncio.get_event_loop().run_until_complete(self.stop_video_input())
+        asyncio.run(self.stop_video_input())
 
     @staticmethod
     def get_displays() -> list[tuple[Optional[str], str]]:

--- a/yarf/rf_libraries/libraries/vnc/__init__.py
+++ b/yarf/rf_libraries/libraries/vnc/__init__.py
@@ -61,15 +61,16 @@ class Vnc(PlatformBase):
                 pass
 
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(perform_check())
+            else:
                 # If a loop is already running, we run the task and wait
                 future = asyncio.run_coroutine_threadsafe(
                     perform_check(), loop
                 )
                 future.result()
-            else:
-                loop.run_until_complete(perform_check())
 
         except (ConnectionRefusedError, OSError) as e:
             raise YARFConnectionError(f"Failed to connect to VNC server: {e}")

--- a/yarf/rf_libraries/libraries/vnc/tests/test_vnc_init.py
+++ b/yarf/rf_libraries/libraries/vnc/tests/test_vnc_init.py
@@ -26,9 +26,13 @@ class TestVnc:
 
     def test_check_connection(self) -> None:
         vnc = Vnc()
-        with pytest.raises(YARFConnectionError) as exc_info:
-            vnc.check_connection()
-        assert exc_info.value.exit_code == YARFExitCode.CONNECTION_ERROR
+        with patch(
+            "yarf.rf_libraries.libraries.vnc.connect",
+            side_effect=ConnectionRefusedError("Connection refused"),
+        ):
+            with pytest.raises(YARFConnectionError) as exc_info:
+                vnc.check_connection()
+            assert exc_info.value.exit_code == YARFExitCode.CONNECTION_ERROR
 
     def test_check_connection_success(self) -> None:
         vnc = Vnc()

--- a/yarf/rf_libraries/libraries/vnc/tests/test_vnc_init.py
+++ b/yarf/rf_libraries/libraries/vnc/tests/test_vnc_init.py
@@ -39,12 +39,9 @@ class TestVnc:
         vnc = Vnc()
         with (
             patch("yarf.rf_libraries.libraries.vnc.connect"),
-            patch(
-                "yarf.rf_libraries.libraries.vnc.asyncio.get_event_loop"
-            ) as mock_get_event_loop,
+            patch("yarf.rf_libraries.libraries.vnc.asyncio.get_running_loop"),
             patch(
                 "yarf.rf_libraries.libraries.vnc.asyncio.run_coroutine_threadsafe"
             ),
         ):
-            mock_get_event_loop.return_value.is_running.return_value = True
             vnc.check_connection()


### PR DESCRIPTION
## Description

The sync check_connection entrypoints in the Mir and Vnc platforms called asyncio.get_event_loop() to obtain (or implicitly create) an event loop. Since CPython PR [python/cpython#98440 (Python 3.12)](https://github.com/python/cpython/pull/98440), that call no longer auto-creates a loop once anything in the process has touched the loop policy and raises RuntimeError instead. With the recent pytest-asyncio 1.x and pytest 9 bumps, xdist workers no longer incidentally have a loop pre-installed.

This PR use `asyncio.get_running_loop()` to detect an already-running event loop and fall back to asyncio.run() via try/except/else.

## Resolved issues



## Documentation



## Tests

Updated
