### PR TITLE
[Infra] Pin click for robocop prek hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,8 @@ repos:
   rev: v8.2.4
   hooks:
   - id: robocop-format
+    additional_dependencies:
+    - click>=8.0.0
     args:
     - --select
     - RenameTestCases
@@ -81,6 +83,8 @@ repos:
     - --select
     - AlignTemplatedTestCases
   - id: robocop
+    additional_dependencies:
+    - click>=8.0.0
     args:
     - --select
     - NAME02


### PR DESCRIPTION
## Description

CI started failing on every PR from 2026-05-27 because the robocop / robocop-format hooks raise ModuleNotFoundError: No module named 'click'. robocop 8.2.4 declares click>=8.0.0 in its requirements, but prek's isolated hook env is not pulling it in transitively on the runner.

Add click>=8.0.0 to additional_dependencies on both robocop hooks so prek installs it explicitly. 

## Resolved issues


## Documentation


## Tests

Verified locally with `prek clean && prek run --all-files`.
CI will also do the check.