### PR TITLE
[Infra] Trigger CI to verify keyword test stability

### DIFF
--- a/.github/workflows/yarf.yaml
+++ b/.github/workflows/yarf.yaml
@@ -1,5 +1,7 @@
 name: Testing and quality control for YARF codebase
 
+# CI trigger: verifying keyword test stability on CI runners.
+
 on:
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
## Description

Triggers CI to reproduce/observe the failing keyword tests (`keyword-tests-noble`).

## Resolved issues

N/A — investigation PR.

## Documentation

N/A

## Tests

Relies on existing CI keyword suite jobs.