### PR TITLE
[BugFix] Fix caplog assertion in test_platform_meta_logs_warning

### DIFF
--- a/yarf/rf_libraries/libraries/tests/test_libraries_init.py
+++ b/yarf/rf_libraries/libraries/tests/test_libraries_init.py
@@ -46,7 +46,7 @@ class TestPlatformMeta:
             pass
 
         assert "FirstPlatform" in SUPPORTED_PLATFORMS
-        assert not caplog.records
+        caplog.clear()
 
         with caplog.at_level("WARNING"):
 


### PR DESCRIPTION
## Description

test_platform_meta_logs_warning asserted `not caplog.records` after creating the first platform, assuming the owasp logger's propagate=False would keep its "platform discovered" WARNING out of caplog. pytest attaches its LogCaptureHandler directly to the owasp logger, so that warning is always captured and the assertion fails deterministically.

Replace the assertion with caplog.clear() so the test only verifies the override warning emitted by the second class definition.

## Resolved issues

Unit test failing issue.

## Documentation



## Tests

CI will tell
