### PR TITLE
[New] Allow per-call OCR similarity/confidence thresholds

### DIFF
--- a/docs/reference/rf_libraries/libraries/library-video_input_base.md
+++ b/docs/reference/rf_libraries/libraries/library-video_input_base.md
@@ -10,7 +10,7 @@
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 ### Return
@@ -26,6 +26,8 @@
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -148,7 +150,7 @@
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -168,6 +170,8 @@
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 

--- a/docs/reference/rf_libraries/libraries/library-video_input_base.md
+++ b/docs/reference/rf_libraries/libraries/library-video_input_base.md
@@ -39,7 +39,7 @@ ${position}=    Find Cursor Position    confidence=0.8
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 #### Return
@@ -57,6 +57,8 @@ list[dictionary]
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
@@ -66,6 +68,8 @@ ${matches}=    Find Text    regex:[0-9]{3}
 &{region}=    Create Dictionary
 ...    left=0    top=0    right=800    bottom=600
 ${matches}=    Find Text    Continue    region=${region}
+${matches}=    Find Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">
@@ -241,7 +245,7 @@ ${matches}=    Match Any    ${templates}    timeout=30
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -263,12 +267,16 @@ tuple[list[dictionary], Image]
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
 ```robotframework
 ${matches}    ${image}=    Match Text    Continue
 Match Text    Continue    timeout=60
+${matches}    ${image}=    Match Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">

--- a/docs/reference/rf_libraries/libraries/mir/library-VideoInput.md
+++ b/docs/reference/rf_libraries/libraries/mir/library-VideoInput.md
@@ -11,7 +11,7 @@
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 ### Return
@@ -27,6 +27,8 @@
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -137,7 +139,7 @@
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -157,6 +159,8 @@
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 

--- a/docs/reference/rf_libraries/libraries/mir/library-VideoInput.md
+++ b/docs/reference/rf_libraries/libraries/mir/library-VideoInput.md
@@ -40,7 +40,7 @@ ${position}=    Find Cursor Position    confidence=0.8
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 #### Return
@@ -58,6 +58,8 @@ list[dictionary]
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
@@ -67,6 +69,8 @@ ${matches}=    Find Text    regex:[0-9]{3}
 &{region}=    Create Dictionary
 ...    left=0    top=0    right=800    bottom=600
 ${matches}=    Find Text    Continue    region=${region}
+${matches}=    Find Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">
@@ -228,7 +232,7 @@ ${matches}=    Match Any    ${templates}    timeout=30
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -250,12 +254,16 @@ tuple[list[dictionary], Image]
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
 ```robotframework
 ${matches}    ${image}=    Match Text    Continue
 Match Text    Continue    timeout=60
+${matches}    ${image}=    Match Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">

--- a/docs/reference/rf_libraries/libraries/vnc/library-VideoInput.md
+++ b/docs/reference/rf_libraries/libraries/vnc/library-VideoInput.md
@@ -11,7 +11,7 @@
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 ### Return
@@ -27,6 +27,8 @@
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 
@@ -138,7 +140,7 @@
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -158,6 +160,8 @@
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 <hr style="border:1px solid grey">
 

--- a/docs/reference/rf_libraries/libraries/vnc/library-VideoInput.md
+++ b/docs/reference/rf_libraries/libraries/vnc/library-VideoInput.md
@@ -40,7 +40,7 @@ ${position}=    Find Cursor Position    confidence=0.8
 ### Find Text
 
 <p>Find the specified text in the provided image or grab a screenshot to search from. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span></p>
-<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in %</p>
+<p>Args: text: text or regex to search for, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. region: region to search for the text. image: image to search from. color: target color of the text. If set, matched text in the wrong color will be skipped. color_tolerance: Color tolerance threshold in % similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.</p>
 <p>Returns: The list of matched text regions where the text was found. Each match is a dictionary with "text", "region", and "confidence".</p>
 
 #### Return
@@ -58,6 +58,8 @@ list[dictionary]
 | image           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
@@ -67,6 +69,8 @@ ${matches}=    Find Text    regex:[0-9]{3}
 &{region}=    Create Dictionary
 ...    left=0    top=0    right=800    bottom=600
 ${matches}=    Find Text    Continue    region=${region}
+${matches}=    Find Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">
@@ -229,7 +233,7 @@ ${matches}=    Match Any    ${templates}    timeout=30
 ### Match Text
 
 <p>Wait for specified text to appear on screen and get the position of the best match. The region can be specified directly in the robot file using <span class="name">RPA.core.geometry.to_region</span>.</p>
-<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text Returns: It returns a tuple with:</p>
+<p>Args: text: text or regex to match, use the format <span class="name">regex:&lt;regex-string&gt;</span> if the text we want to find is a regex. timeout: Time to wait for the text to appear region: The region to search for the text color: The color of the searched text color_tolerance: The tolerance of the color of the searched text similarity: Minimum similarity percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only. confidence: Minimum confidence percentage (0-100) for a match when using RapidOCR. If set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only. Returns: It returns a tuple with:</p>
 <ul>
 <li>The list of matched text regions where the text was found, sorted by confidence.</li>
 <li>The image (used for debugging). Each match is a dictionary with "text", "region", and "confidence".</li>
@@ -251,12 +255,16 @@ tuple[list[dictionary], Image]
 | region          | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color           | None    | None          | POSITIONAL_OR_NAMED | No       |
 | color_tolerance | integer | 20            | POSITIONAL_OR_NAMED | No       |
+| similarity      | None    | None          | POSITIONAL_OR_NAMED | No       |
+| confidence      | None    | None          | POSITIONAL_OR_NAMED | No       |
 
 #### Example
 
 ```robotframework
 ${matches}    ${image}=    Match Text    Continue
 Match Text    Continue    timeout=60
+${matches}    ${image}=    Match Text    Continue
+...    similarity=90    confidence=70
 ```
 
 <hr style="border:1px solid grey">

--- a/tests/keyword_suite/video_text_test.robot
+++ b/tests/keyword_suite/video_text_test.robot
@@ -29,6 +29,7 @@ Test Text Keywords with Rapid Ocr
     Test Keyword Get Position Of Target String
     Test Keyword Find Text
     Test Keyword Match Text
+    Test Keyword Text Threshold Overrides
 
 Test Text Keywords with Tesseract
     [Tags]                  yarf:certification_status: blocker
@@ -161,3 +162,30 @@ Test Keyword Match Text
 
     Run Keyword And Expect Error                    ValueError: *
     ...                     Match Text              not_expected            region=${region}
+
+Test Keyword Text Threshold Overrides
+    [Tags]                  yarf:certification_status: blocker
+    ${region}=              Catenate
+    ...                     SEPARATOR=,
+    ...                     ${REGEX_REGION.left}
+    ...                     ${REGEX_REGION.top}
+    ...                     ${REGEX_REGION.right}
+    ...                     ${REGEX_REGION.bottom}
+    Set Suite Variable      \${OCR_SIMILARITY_THRESHOLD}                    not_a_number
+    Set Suite Variable      \${OCR_CONFIDENCE_THRESHOLD}                    not_a_number
+    ${matched_text}=        Find Text
+    ...                     AB123cd
+    ...                     region=${REGEX_REGION}
+    ...                     similarity=100
+    ...                     confidence=70
+    Should Not Be Empty     ${matched_text}
+    Should Be Equal As Strings                      ${matched_text[0]['text']}                      AB123cd
+
+    ${matches}              ${image}=               Match Text
+    ...                     AB123cd
+    ...                     region=${region}
+    ...                     similarity=100
+    ...                     confidence=70
+    Should Not Be Empty     ${matches}
+    ${is_image}=            Evaluate                isinstance($image, __import__('PIL.Image').Image.Image)
+    Should Be True          ${is_image}

--- a/yarf/rf_libraries/libraries/ocr/rapidocr.py
+++ b/yarf/rf_libraries/libraries/ocr/rapidocr.py
@@ -96,6 +96,8 @@ class RapidOCRReader:
         text: str,
         region: Region | None = None,
         partial: bool = True,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> list[dict]:
         """
         Scan image for text and return a list of regions that contain it (or
@@ -106,6 +108,12 @@ class RapidOCRReader:
             text: Text to find in image.
             region: Limit the region of the screen where to look.
             partial: Use partial matching.
+            similarity: Minimum similarity percentage (0-100) for a match.
+              If None, falls back to ${OCR_SIMILARITY_THRESHOLD} or the
+              default threshold.
+            confidence: Minimum confidence percentage (0-100) for a match.
+              If None, falls back to ${OCR_CONFIDENCE_THRESHOLD} or the
+              default threshold.
 
         Returns:
             List of regions with text found in image.
@@ -135,7 +143,9 @@ class RapidOCRReader:
         for item in result:
             item.confidence *= 100
 
-        matches = self.get_matches(result, text, partial)
+        matches = self.get_matches(
+            result, text, partial, similarity, confidence
+        )
 
         if region is not None:
             for match in matches:
@@ -148,6 +158,8 @@ class RapidOCRReader:
         result: list[OCRResult],
         match_text: str,
         partial: bool,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> list[dict]:
         """
         Get matches from OCR results based on similarity and confidence.
@@ -156,6 +168,12 @@ class RapidOCRReader:
             result: List with the OCR results.
             match_text: Text to match.
             partial: Use partial matching.
+            similarity: Minimum similarity percentage (0-100) for a match.
+              If None, falls back to ${OCR_SIMILARITY_THRESHOLD} or the
+              default threshold.
+            confidence: Minimum confidence percentage (0-100) for a match.
+              If None, falls back to ${OCR_CONFIDENCE_THRESHOLD} or the
+              default threshold.
 
         Returns:
             List of OCR matches containing the text.
@@ -204,6 +222,8 @@ class RapidOCRReader:
                 BuiltIn().fail(
                     f"OCR_SIMILARITY_THRESHOLD must be a number, got {similarity_threshold_str}"
                 )
+        if similarity is not None:
+            similarity_threshold = similarity
 
         confidence_threshold = self.DEFAULT_CONFIDENCE_THRESHOLD
         confidence_threshold_str = BuiltIn().get_variable_value(
@@ -219,6 +239,8 @@ class RapidOCRReader:
                 BuiltIn().fail(
                     f"OCR_CONFIDENCE_THRESHOLD must be a number, got {confidence_threshold_str}"
                 )
+        if confidence is not None:
+            confidence_threshold = confidence
 
         matches = []
         for item in result:

--- a/yarf/rf_libraries/libraries/ocr/rapidocr.py
+++ b/yarf/rf_libraries/libraries/ocr/rapidocr.py
@@ -61,6 +61,11 @@ class RapidOCRReader:
     DEFAULT_CONFIDENCE_THRESHOLD: float = 70.0
     SIMILARITY_LOG_THRESHOLD: float = 80.0
 
+    @staticmethod
+    def _validate_threshold(name: str, value: float) -> None:
+        if not 0 <= value <= 100:
+            BuiltIn().fail(f"{name} must be between 0 and 100, got {value}")
+
     def __new__(cls) -> "RapidOCRReader":
         if not hasattr(cls, "instance"):
             print("Creating RapidOCR instance")
@@ -96,6 +101,8 @@ class RapidOCRReader:
         text: str,
         region: Region | None = None,
         partial: bool = True,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> list[dict]:
         """
         Scan image for text and return a list of regions that contain it (or
@@ -106,6 +113,12 @@ class RapidOCRReader:
             text: Text to find in image.
             region: Limit the region of the screen where to look.
             partial: Use partial matching.
+            similarity: Minimum similarity percentage (0-100) for a match.
+              If None, falls back to ${OCR_SIMILARITY_THRESHOLD} or the
+              default threshold.
+            confidence: Minimum confidence percentage (0-100) for a match.
+              If None, falls back to ${OCR_CONFIDENCE_THRESHOLD} or the
+              default threshold.
 
         Returns:
             List of regions with text found in image.
@@ -113,6 +126,11 @@ class RapidOCRReader:
         Raises:
             ValueError: Empty search string.
         """
+        if similarity is not None:
+            RapidOCRReader._validate_threshold("similarity", similarity)
+        if confidence is not None:
+            RapidOCRReader._validate_threshold("confidence", confidence)
+
         image_obj = to_image(image)
         if region is not None:
             image_obj = image_obj.crop(region.as_tuple())  # type: ignore[union-attr]
@@ -135,7 +153,9 @@ class RapidOCRReader:
         for item in result:
             item.confidence *= 100
 
-        matches = self.get_matches(result, text, partial)
+        matches = self.get_matches(
+            result, text, partial, similarity, confidence
+        )
 
         if region is not None:
             for match in matches:
@@ -148,6 +168,8 @@ class RapidOCRReader:
         result: list[OCRResult],
         match_text: str,
         partial: bool,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> list[dict]:
         """
         Get matches from OCR results based on similarity and confidence.
@@ -156,6 +178,12 @@ class RapidOCRReader:
             result: List with the OCR results.
             match_text: Text to match.
             partial: Use partial matching.
+            similarity: Minimum similarity percentage (0-100) for a match.
+              If None, falls back to ${OCR_SIMILARITY_THRESHOLD} or the
+              default threshold.
+            confidence: Minimum confidence percentage (0-100) for a match.
+              If None, falls back to ${OCR_CONFIDENCE_THRESHOLD} or the
+              default threshold.
 
         Returns:
             List of OCR matches containing the text.
@@ -190,35 +218,43 @@ class RapidOCRReader:
             # we don't match against a substring of the query
             return rapidfuzz.fuzz.ratio(q, text)
 
-        similarity_threshold = self.DEFAULT_SIMILARITY_THRESHOLD
-        similarity_threshold_str = BuiltIn().get_variable_value(
-            "${OCR_SIMILARITY_THRESHOLD}"
-        )
-        if similarity_threshold_str is not None:
-            logger.debug(
-                f"OCR similarity threshold set to {similarity_threshold_str}"
+        if similarity is not None:
+            RapidOCRReader._validate_threshold("similarity", similarity)
+            similarity_threshold = similarity
+        else:
+            similarity_threshold = self.DEFAULT_SIMILARITY_THRESHOLD
+            similarity_threshold_str = BuiltIn().get_variable_value(
+                "${OCR_SIMILARITY_THRESHOLD}"
             )
-            try:
-                similarity_threshold = float(similarity_threshold_str)
-            except ValueError:
-                BuiltIn().fail(
-                    f"OCR_SIMILARITY_THRESHOLD must be a number, got {similarity_threshold_str}"
+            if similarity_threshold_str is not None:
+                logger.debug(
+                    f"OCR similarity threshold set to {similarity_threshold_str}"
                 )
+                try:
+                    similarity_threshold = float(similarity_threshold_str)
+                except ValueError:
+                    BuiltIn().fail(
+                        f"OCR_SIMILARITY_THRESHOLD must be a number, got {similarity_threshold_str}"
+                    )
 
-        confidence_threshold = self.DEFAULT_CONFIDENCE_THRESHOLD
-        confidence_threshold_str = BuiltIn().get_variable_value(
-            "${OCR_CONFIDENCE_THRESHOLD}"
-        )
-        if confidence_threshold_str is not None:
-            logger.debug(
-                f"OCR confidence threshold set to {confidence_threshold_str}"
+        if confidence is not None:
+            RapidOCRReader._validate_threshold("confidence", confidence)
+            confidence_threshold = confidence
+        else:
+            confidence_threshold = self.DEFAULT_CONFIDENCE_THRESHOLD
+            confidence_threshold_str = BuiltIn().get_variable_value(
+                "${OCR_CONFIDENCE_THRESHOLD}"
             )
-            try:
-                confidence_threshold = float(confidence_threshold_str)
-            except ValueError:
-                BuiltIn().fail(
-                    f"OCR_CONFIDENCE_THRESHOLD must be a number, got {confidence_threshold_str}"
+            if confidence_threshold_str is not None:
+                logger.debug(
+                    f"OCR confidence threshold set to {confidence_threshold_str}"
                 )
+                try:
+                    confidence_threshold = float(confidence_threshold_str)
+                except ValueError:
+                    BuiltIn().fail(
+                        f"OCR_CONFIDENCE_THRESHOLD must be a number, got {confidence_threshold_str}"
+                    )
 
         matches = []
         for item in result:

--- a/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
+++ b/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
@@ -179,6 +179,44 @@ class TestRapidOCR:
             }
         ]
 
+    def test_get_matches_threshold_override(self, mock_reader):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello", 90),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn.get_variable_value"
+        ) as mock_get_variable_value:
+            mock_get_variable_value.side_effect = lambda var, *a, **kw: {
+                "${OCR_CONFIDENCE_THRESHOLD}": 80,
+                "${OCR_SIMILARITY_THRESHOLD}": 80,
+            }.get(var)
+            # Per-call confidence=95 overrides the variable (80), rejecting
+            # the 90-confidence item that would otherwise match.
+            result = RapidOCRReader.get_matches(
+                mock_reader, items, "Hello", False, confidence=95
+            )
+
+        assert result == []
+
+    def test_get_matches_similarity_override(self, mock_reader):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello", 90),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn.get_variable_value"
+        ) as mock_get_variable_value:
+            mock_get_variable_value.side_effect = lambda var, *a, **kw: {
+                "${OCR_CONFIDENCE_THRESHOLD}": 80,
+                "${OCR_SIMILARITY_THRESHOLD}": 80,
+            }.get(var)
+            # Per-call similarity=101 overrides the variable (80), rejecting
+            # the item that would otherwise match.
+            result = RapidOCRReader.get_matches(
+                mock_reader, items, "Hello", False, similarity=101
+            )
+
+        assert result == []
+
     def test_get_matches_no_matches(self, mock_reader):
         items = [
             OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello World", 90),

--- a/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
+++ b/yarf/rf_libraries/libraries/ocr/tests/test_rapidocr.py
@@ -89,6 +89,30 @@ class TestRapidOCR:
             }
         ]
 
+    def test_find_threshold_override(self, mock_reader):
+        mock_reader.reader.return_value = MockRapidOCROutput(
+            boxes=np.array([[[0, 0], [0, 0], [0, 0], [0, 0]]]),
+            txts=("Hello",),
+            scores=(90,),
+        )
+        mock_reader.get_matches.return_value = []
+
+        result = RapidOCRReader.find(
+            mock_reader,
+            None,
+            "Hello",
+            similarity=95,
+            confidence=90,
+        )
+
+        assert result == []
+        assert mock_reader.get_matches.call_args.args[1:] == (
+            "Hello",
+            True,
+            95,
+            90,
+        )
+
     def test_find_empty_search_string(self, mock_reader):
         with pytest.raises(ValueError) as e:
             RapidOCRReader.find(mock_reader, None, "")
@@ -178,6 +202,119 @@ class TestRapidOCR:
                 "similarity": 100,
             }
         ]
+
+    def test_get_matches_threshold_override(self, mock_reader):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello", 90),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn.get_variable_value"
+        ) as mock_get_variable_value:
+            mock_get_variable_value.side_effect = lambda var, *a, **kw: {
+                "${OCR_CONFIDENCE_THRESHOLD}": 80,
+                "${OCR_SIMILARITY_THRESHOLD}": 80,
+            }.get(var)
+            # Per-call confidence=95 overrides the variable (80), rejecting
+            # the 90-confidence item that would otherwise match.
+            result = RapidOCRReader.get_matches(
+                mock_reader, items, "Hello", False, confidence=95
+            )
+
+        assert result == []
+
+    def test_get_matches_similarity_override(self, mock_reader):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello!", 90),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn.get_variable_value"
+        ) as mock_get_variable_value:
+            mock_get_variable_value.side_effect = lambda var, *a, **kw: {
+                "${OCR_CONFIDENCE_THRESHOLD}": 80,
+                "${OCR_SIMILARITY_THRESHOLD}": 80,
+            }.get(var)
+            # A less-than-perfect result matches the variable threshold (80),
+            # but not the valid per-call threshold (95).
+            result = RapidOCRReader.get_matches(
+                mock_reader, items, "Hello", False, similarity=95
+            )
+
+        assert result == []
+
+    @pytest.mark.parametrize(
+        ("parameter", "value"),
+        [
+            ("similarity", -1),
+            ("similarity", 101),
+            ("confidence", -1),
+            ("confidence", 101),
+        ],
+    )
+    def test_get_matches_invalid_threshold_override(
+        self, mock_reader, parameter, value
+    ):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello", 90),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn"
+        ) as mock_builtin_cls:
+            mock_builtin = mock_builtin_cls.return_value
+            mock_builtin.fail.side_effect = AssertionError("fail called")
+            with pytest.raises(AssertionError, match="fail called"):
+                RapidOCRReader.get_matches(
+                    mock_reader,
+                    items,
+                    "Hello",
+                    False,
+                    **{parameter: value},
+                )
+
+        mock_builtin.fail.assert_called_once_with(
+            f"{parameter} must be between 0 and 100, got {value}"
+        )
+
+    @pytest.mark.parametrize(
+        ("parameter", "ignored_variable", "fallback_variable"),
+        [
+            (
+                "similarity",
+                "${OCR_SIMILARITY_THRESHOLD}",
+                "${OCR_CONFIDENCE_THRESHOLD}",
+            ),
+            (
+                "confidence",
+                "${OCR_CONFIDENCE_THRESHOLD}",
+                "${OCR_SIMILARITY_THRESHOLD}",
+            ),
+        ],
+    )
+    def test_get_matches_override_precedes_invalid_variable(
+        self,
+        mock_reader,
+        parameter,
+        ignored_variable,
+        fallback_variable,
+    ):
+        items = [
+            OCRResult([[0, 0], [1, 0], [1, 1], [0, 1]], "Hello", 100),
+        ]
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn.get_variable_value"
+        ) as mock_get_variable_value:
+            mock_get_variable_value.side_effect = lambda var, *a, **kw: (
+                "not_a_number" if var == ignored_variable else 80
+            )
+            result = RapidOCRReader.get_matches(
+                mock_reader,
+                items,
+                "Hello",
+                False,
+                **{parameter: 100},
+            )
+
+        assert result
+        mock_get_variable_value.assert_called_once_with(fallback_variable)
 
     def test_get_matches_no_matches(self, mock_reader):
         items = [

--- a/yarf/rf_libraries/libraries/tests/test_video_input_base.py
+++ b/yarf/rf_libraries/libraries/tests/test_video_input_base.py
@@ -502,7 +502,11 @@ class TestVideoInputBase:
                 mock_log_image.assert_not_called()
 
         stub_videoinput.ocr.find.assert_called_once_with(
-            stub_videoinput.grab_screenshot.return_value, "text", region=None
+            stub_videoinput.grab_screenshot.return_value,
+            "text",
+            region=None,
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.parametrize(
@@ -552,6 +556,8 @@ class TestVideoInputBase:
             stub_videoinput.grab_screenshot.return_value,
             "text",
             region=expected_region,
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.asyncio
@@ -573,7 +579,7 @@ class TestVideoInputBase:
         await stub_videoinput.find_text("text", image=image)
 
         stub_videoinput.ocr.find.assert_called_once_with(
-            image, "text", region=None
+            image, "text", region=None, similarity=None, confidence=None
         )
 
     @pytest.mark.asyncio
@@ -605,14 +611,33 @@ class TestVideoInputBase:
                     stub_videoinput.grab_screenshot.return_value,
                     "text",
                     region=None,
+                    similarity=None,
+                    confidence=None,
                 ),
                 call(
                     stub_videoinput.grab_screenshot.return_value,
                     "test",
                     region=None,
+                    similarity=None,
+                    confidence=None,
                 ),
             ],
             any_order=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_text_threshold_override(self, stub_videoinput):
+        """
+        Test that per-call similarity/confidence are passed to ocr.find.
+        """
+        image = Mock()
+        stub_videoinput.ocr.find = Mock(return_value=[])
+        await stub_videoinput.find_text(
+            "text", image=image, similarity=100, confidence=95
+        )
+
+        stub_videoinput.ocr.find.assert_called_once_with(
+            image, "text", region=None, similarity=100, confidence=95
         )
 
     @pytest.mark.asyncio
@@ -636,6 +661,8 @@ class TestVideoInputBase:
             stub_videoinput.grab_screenshot.return_value,
             "text",
             region=Region(0, 0, 1, 1),
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.asyncio

--- a/yarf/rf_libraries/libraries/tests/test_video_input_base.py
+++ b/yarf/rf_libraries/libraries/tests/test_video_input_base.py
@@ -535,7 +535,11 @@ class TestVideoInputBase:
                 mock_log_image.assert_not_called()
 
         stub_videoinput.ocr.find.assert_called_once_with(
-            stub_videoinput.grab_screenshot.return_value, "text", region=None
+            stub_videoinput.grab_screenshot.return_value,
+            "text",
+            region=None,
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.parametrize(
@@ -585,6 +589,8 @@ class TestVideoInputBase:
             stub_videoinput.grab_screenshot.return_value,
             "text",
             region=expected_region,
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.asyncio
@@ -606,7 +612,7 @@ class TestVideoInputBase:
         await stub_videoinput.find_text("text", image=image)
 
         stub_videoinput.ocr.find.assert_called_once_with(
-            image, "text", region=None
+            image, "text", region=None, similarity=None, confidence=None
         )
 
     @pytest.mark.asyncio
@@ -638,14 +644,84 @@ class TestVideoInputBase:
                     stub_videoinput.grab_screenshot.return_value,
                     "text",
                     region=None,
+                    similarity=None,
+                    confidence=None,
                 ),
                 call(
                     stub_videoinput.grab_screenshot.return_value,
                     "test",
                     region=None,
+                    similarity=None,
+                    confidence=None,
                 ),
             ],
             any_order=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_text_with_regex_validates_thresholds(
+        self, stub_videoinput
+    ):
+        """
+        Test regex searches validate RapidOCR thresholds without matches.
+        """
+        image = Mock()
+        stub_videoinput.ocr.read = Mock(return_value="text")
+        with patch(
+            "yarf.rf_libraries.libraries.ocr.rapidocr.BuiltIn"
+        ) as mock_builtin:
+            mock_builtin.return_value.fail.side_effect = AssertionError(
+                "fail called"
+            )
+            with pytest.raises(AssertionError, match="fail called"):
+                await stub_videoinput.find_text(
+                    "regex:missing",
+                    image=image,
+                    similarity=101,
+                )
+
+        mock_builtin.return_value.fail.assert_called_once_with(
+            "similarity must be between 0 and 100, got 101"
+        )
+        stub_videoinput.ocr.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_find_text_with_tesseract_threshold_override(
+        self, stub_videoinput
+    ):
+        stub_videoinput.set_ocr_method("tesseract")
+        image = Mock()
+        with (
+            patch.object(
+                stub_videoinput.ocr, "read", return_value="text"
+            ) as mock_read,
+            patch.object(
+                stub_videoinput.ocr, "find", return_value=[]
+            ) as mock_find,
+        ):
+            await stub_videoinput.find_text(
+                "regex:text",
+                image=image,
+                similarity=100,
+                confidence=95,
+            )
+
+        mock_read.assert_called_once_with(image)
+        mock_find.assert_called_once_with(image, "text", region=None)
+
+    @pytest.mark.asyncio
+    async def test_find_text_threshold_override(self, stub_videoinput):
+        """
+        Test that per-call similarity/confidence are passed to ocr.find.
+        """
+        image = Mock()
+        stub_videoinput.ocr.find = Mock(return_value=[])
+        await stub_videoinput.find_text(
+            "text", image=image, similarity=100, confidence=95
+        )
+
+        stub_videoinput.ocr.find.assert_called_once_with(
+            image, "text", region=None, similarity=100, confidence=95
         )
 
     @pytest.mark.asyncio
@@ -669,6 +745,8 @@ class TestVideoInputBase:
             stub_videoinput.grab_screenshot.return_value,
             "text",
             region=Region(0, 0, 1, 1),
+            similarity=None,
+            confidence=None,
         )
 
     @pytest.mark.asyncio

--- a/yarf/rf_libraries/libraries/video_input_base.py
+++ b/yarf/rf_libraries/libraries/video_input_base.py
@@ -53,7 +53,9 @@ class VideoInputBase(ABC):
         When using RapidOCR as the OCR method, you can set the Robot Framework
         variables `${OCR_SIMILARITY_THRESHOLD}` and `${OCR_CONFIDENCE_THRESHOLD}`
         to control the minimum similarity and confidence required for text
-        matches (values between 0 and 100).
+        matches (values between 0 and 100). These can be overridden per call
+        via the `similarity` and `confidence` arguments of `Find Text` and
+        `Match Text`.
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
@@ -228,6 +230,8 @@ class VideoInputBase(ABC):
         text: str,
         image: Optional[Image.Image] = None,
         region: Optional[Region] = None,
+        similarity: Optional[float] = None,
+        confidence: Optional[float] = None,
     ) -> list[dict]:
         matched_text_regions: list[dict] = []
         regex_prefix = "regex:"
@@ -238,11 +242,23 @@ class VideoInputBase(ABC):
             )
             for match_text in unique_match_texts:
                 matched_text_regions.extend(
-                    self.ocr.find(image, match_text, region=region)  # type: ignore[arg-type]
+                    self.ocr.find(
+                        image,  # type: ignore[arg-type]
+                        match_text,
+                        region=region,
+                        similarity=similarity,
+                        confidence=confidence,
+                    )
                 )
 
         else:
-            matched_text_regions = self.ocr.find(image, text, region=region)  # type: ignore[arg-type]
+            matched_text_regions = self.ocr.find(
+                image,  # type: ignore[arg-type]
+                text,
+                region=region,
+                similarity=similarity,
+                confidence=confidence,
+            )
 
         return matched_text_regions
 
@@ -254,6 +270,8 @@ class VideoInputBase(ABC):
         image: Optional[Image.Image] = None,
         color: Optional[Union[RGB, tuple[int, int, int]]] = None,
         color_tolerance: int = 20,
+        similarity: Optional[float] = None,
+        confidence: Optional[float] = None,
     ) -> List[dict]:
         """
         Find the specified text in the provided image or grab a screenshot to
@@ -267,6 +285,10 @@ class VideoInputBase(ABC):
             image: image to search from.
             color: target color of the text. If set, matched text in the wrong color will be skipped.
             color_tolerance: Color tolerance threshold in %
+            similarity: Minimum similarity percentage (0-100) for a match. If
+                  set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only.
+            confidence: Minimum confidence percentage (0-100) for a match. If
+                  set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.
 
         Returns:
             The list of matched text regions where the text was found. Each
@@ -280,7 +302,11 @@ class VideoInputBase(ABC):
 
         matched_text_regions: list[dict] = []
         ocr_text_regions: list[dict] = self._get_ocr_text_from_image(
-            text, image=image, region=region
+            text,
+            image=image,
+            region=region,
+            similarity=similarity,
+            confidence=confidence,
         )
         if color is None:
             matched_text_regions = ocr_text_regions
@@ -344,8 +370,8 @@ class VideoInputBase(ABC):
         # Log all the matches if in debug mode (If there are any matches)
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
             for match in matched_text_regions:
-                similarity = f"{match['similarity']:.2f}"
-                confidence = f"{match['confidence']:.2f}"
+                similarity_str = f"{match['similarity']:.2f}"
+                confidence_str = f"{match['confidence']:.2f}"
                 matched_image = self._draw_region_on_image(
                     image.copy(), match["region"]
                 )
@@ -354,7 +380,7 @@ class VideoInputBase(ABC):
                 log_image(
                     matched_image,
                     f"Found text matching '{text}' with similarity "
-                    f"{similarity}, confidence {confidence}: "
+                    f"{similarity_str}, confidence {confidence_str}: "
                     f"'{match['text']}'",
                 )
 
@@ -368,6 +394,8 @@ class VideoInputBase(ABC):
         region: Region | tuple[int] | None = None,
         color: RGB | tuple[int] | None = None,
         color_tolerance: int = 20,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> tuple[list[dict], Image.Image]:
         """
         Wait for specified text to appear on screen and get the position of the
@@ -381,6 +409,10 @@ class VideoInputBase(ABC):
             region: The region to search for the text
             color: The color of the searched text
             color_tolerance: The tolerance of the color of the searched text
+            similarity: Minimum similarity percentage (0-100) for a match. If
+                  set, overrides ${OCR_SIMILARITY_THRESHOLD} for this call only.
+            confidence: Minimum confidence percentage (0-100) for a match. If
+                  set, overrides ${OCR_CONFIDENCE_THRESHOLD} for this call only.
         Returns:
             It returns a tuple with:
              - The list of matched text regions where the text was found,
@@ -407,7 +439,11 @@ class VideoInputBase(ABC):
             # if no color was given, simply find any text
             if color_rgb is None:
                 text_matches = await self.find_text(
-                    text, image=image, region=region
+                    text,
+                    image=image,
+                    region=region,
+                    similarity=similarity,
+                    confidence=confidence,
                 )
 
             else:  # a color was given.
@@ -417,6 +453,8 @@ class VideoInputBase(ABC):
                     region=region,
                     color=color_rgb,
                     color_tolerance=color_tolerance,
+                    similarity=similarity,
+                    confidence=confidence,
                 )
 
             if text_matches:

--- a/yarf/rf_libraries/libraries/video_input_base.py
+++ b/yarf/rf_libraries/libraries/video_input_base.py
@@ -59,7 +59,9 @@ class VideoInputBase(ABC):
         When using RapidOCR as the OCR method, you can set the Robot Framework
         variables `${OCR_SIMILARITY_THRESHOLD}` and `${OCR_CONFIDENCE_THRESHOLD}`
         to control the minimum similarity and confidence required for text
-        matches (values between 0 and 100).
+        matches (values between 0 and 100). These can be overridden per call
+        via the `similarity` and `confidence` arguments of `Find Text` and
+        `Match Text`.
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
@@ -254,21 +256,43 @@ class VideoInputBase(ABC):
         text: str,
         image: Optional[Image.Image] = None,
         region: Optional[Region] = None,
+        similarity: Optional[float] = None,
+        confidence: Optional[float] = None,
     ) -> list[dict]:
         matched_text_regions: list[dict] = []
         regex_prefix = "regex:"
+
+        if isinstance(self.ocr, RapidOCRReader):
+            if similarity is not None:
+                RapidOCRReader._validate_threshold("similarity", similarity)
+            if confidence is not None:
+                RapidOCRReader._validate_threshold("confidence", confidence)
+
+        def find_match(match_text: str) -> list[dict]:
+            if isinstance(self.ocr, RapidOCRReader):
+                return self.ocr.find(
+                    image,  # type: ignore[arg-type]
+                    match_text,
+                    region=region,
+                    similarity=similarity,
+                    confidence=confidence,
+                )
+            return self.ocr.find(
+                image,  # type: ignore[arg-type]
+                match_text,
+                region=region,
+            )
+
         if text.startswith(regex_prefix):
             image_text = self.ocr.read(image)  # type: ignore[arg-type]
             unique_match_texts = set(
                 re.findall(rf"{text[len(regex_prefix) :]}", image_text)
             )
             for match_text in unique_match_texts:
-                matched_text_regions.extend(
-                    self.ocr.find(image, match_text, region=region)  # type: ignore[arg-type]
-                )
+                matched_text_regions.extend(find_match(match_text))
 
         else:
-            matched_text_regions = self.ocr.find(image, text, region=region)  # type: ignore[arg-type]
+            matched_text_regions = find_match(text)
 
         return matched_text_regions
 
@@ -280,6 +304,8 @@ class VideoInputBase(ABC):
         image: Optional[Image.Image] = None,
         color: Optional[Union[RGB, tuple[int, int, int]]] = None,
         color_tolerance: int = 20,
+        similarity: Optional[float] = None,
+        confidence: Optional[float] = None,
     ) -> List[dict]:
         """
         Find the specified text in the provided image or grab a screenshot to
@@ -293,6 +319,12 @@ class VideoInputBase(ABC):
             image: image to search from.
             color: target color of the text. If set, matched text in the wrong color will be skipped.
             color_tolerance: Color tolerance threshold in %
+            similarity: Minimum similarity percentage (0-100) for a match when
+                  using RapidOCR. If set, overrides
+                  ${OCR_SIMILARITY_THRESHOLD} for this call only.
+            confidence: Minimum confidence percentage (0-100) for a match when
+                  using RapidOCR. If set, overrides
+                  ${OCR_CONFIDENCE_THRESHOLD} for this call only.
 
         Returns:
             The list of matched text regions where the text was found. Each
@@ -304,6 +336,8 @@ class VideoInputBase(ABC):
             | &{region}=    Create Dictionary
             | ...    left=0    top=0    right=800    bottom=600
             | ${matches}=    Find Text    Continue    region=${region}
+            | ${matches}=    Find Text    Continue
+            | ...    similarity=90    confidence=70
         """
         if isinstance(region, dict):
             region = Region(**region)
@@ -313,7 +347,11 @@ class VideoInputBase(ABC):
 
         matched_text_regions: list[dict] = []
         ocr_text_regions: list[dict] = self._get_ocr_text_from_image(
-            text, image=image, region=region
+            text,
+            image=image,
+            region=region,
+            similarity=similarity,
+            confidence=confidence,
         )
         if color is None:
             matched_text_regions = ocr_text_regions
@@ -329,8 +367,8 @@ class VideoInputBase(ABC):
         # Log all the matches if in debug mode (If there are any matches)
         if os.getenv("YARF_LOG_LEVEL") == "DEBUG":
             for match in matched_text_regions:
-                similarity = f"{match['similarity']:.2f}"
-                confidence = f"{match['confidence']:.2f}"
+                similarity_str = f"{match['similarity']:.2f}"
+                confidence_str = f"{match['confidence']:.2f}"
                 matched_image = self._draw_region_on_image(
                     image.copy(), match["region"]
                 )
@@ -339,7 +377,7 @@ class VideoInputBase(ABC):
                 log_image(
                     matched_image,
                     f"Found text matching '{text}' with similarity "
-                    f"{similarity}, confidence {confidence}: "
+                    f"{similarity_str}, confidence {confidence_str}: "
                     f"'{match['text']}'",
                 )
 
@@ -439,6 +477,8 @@ class VideoInputBase(ABC):
         region: Region | tuple[int] | None = None,
         color: RGB | tuple[int] | None = None,
         color_tolerance: int = 20,
+        similarity: float | None = None,
+        confidence: float | None = None,
     ) -> tuple[list[dict], Image.Image]:
         """
         Wait for specified text to appear on screen and get the position of the
@@ -452,6 +492,12 @@ class VideoInputBase(ABC):
             region: The region to search for the text
             color: The color of the searched text
             color_tolerance: The tolerance of the color of the searched text
+            similarity: Minimum similarity percentage (0-100) for a match when
+                  using RapidOCR. If set, overrides
+                  ${OCR_SIMILARITY_THRESHOLD} for this call only.
+            confidence: Minimum confidence percentage (0-100) for a match when
+                  using RapidOCR. If set, overrides
+                  ${OCR_CONFIDENCE_THRESHOLD} for this call only.
         Returns:
             It returns a tuple with:
              - The list of matched text regions where the text was found,
@@ -464,6 +510,8 @@ class VideoInputBase(ABC):
         Example:
             | ${matches}    ${image}=    Match Text    Continue
             | Match Text    Continue    timeout=60
+            | ${matches}    ${image}=    Match Text    Continue
+            | ...    similarity=90    confidence=70
         """
         region = to_region(region)
         print(f"\nLooking for '{text}'")
@@ -490,7 +538,11 @@ class VideoInputBase(ABC):
             # if no color was given, simply find any text
             if color_rgb is None:
                 text_matches = await self.find_text(
-                    text, image=image, region=region
+                    text,
+                    image=image,
+                    region=region,
+                    similarity=similarity,
+                    confidence=confidence,
                 )
 
             else:  # a color was given.
@@ -500,6 +552,8 @@ class VideoInputBase(ABC):
                     region=region,
                     color=color_rgb,
                     color_tolerance=color_tolerance,
+                    similarity=similarity,
+                    confidence=confidence,
                 )
 
             if text_matches:


### PR DESCRIPTION
## Description

`Match Text` and `Find Text` now accept optional `similarity` and `confidence` thresholds for a single call.

Previously, changing these thresholds required updating the suite-wide `${OCR_SIMILARITY_THRESHOLD}` or `${OCR_CONFIDENCE_THRESHOLD}` variables, which affected every match.

Per-call values override the corresponding global variables. When omitted, existing behavior is unchanged: the global variable is used first, followed by the default. This allows individual calls to use stricter or less strict thresholds without affecting the rest of the suite.

## Documentation

Updated the `VideoInputBase`, `Find Text`, and `Match Text` docstrings. Regenerated the library reference markdown.

## Tests

Added unit tests:
- `test_get_matches_threshold_override` — per-call `confidence` overrides the `${OCR_CONFIDENCE_THRESHOLD}` variable and rejects an otherwise-matching item.
- `test_find_text_threshold_override` — `similarity`/`confidence` propagate to `ocr.find`. Existing `ocr.find` call assertions updated for the new kwargs.

## Resolved issues

For the authd e2e tests we sometimes have to reduce the similarity or confidence thresholds for matching strings which the OCR struggles to read accurately, for example [here](https://github.com/canonical/authd/pull/1828) or [here](https://github.com/canonical/authd/pull/1684). However, we don't want to reduce the thresholds globally, because that would increase the rate of false positives.
