### PR TITLE
[Infra] Remove obsolete system Python workaround

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,9 +101,8 @@ ______________________________________________________________________
 
 ### `yarf/rf_libraries/libraries/mir/`
 
-- Mir/Wayland platform implementation. Tests may require system Wayland/Mir
-  dependencies and a system-Python-backed uv environment because uv-managed
-  Python builds lack `os.memfd_create`.
+- Mir/Wayland platform implementation. Tests may require system
+  Wayland/Mir dependencies.
 
 ### `yarf/rf_libraries/libraries/vnc/`
 

--- a/.github/scripts/yarf/run-tutorial-tests.sh
+++ b/.github/scripts/yarf/run-tutorial-tests.sh
@@ -9,6 +9,8 @@ sudo apt-get --yes --no-install-recommends install \
   libadwaita-1-dev \
   gir1.2-adw-1
 
+# --system-site-packages makes the distro-provided python3-gi package
+# available to simple-counter.
 uv venv --python=/usr/bin/python3 --system-site-packages \
   --project="$(pwd)/examples/yarf-example-simple-counter"
 

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run test and coverage
         run: |
-          uv --no-managed-python venv --system-site-packages
+          uv venv
           uv sync
           uv run pytest -n=auto --cov=yarf --cov-fail-under=100 --cov-report term-missing
           coverage xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,7 @@ repos:
   rev: e73b8ba0c1316be565983236c72e653ad44e6b66
   hooks:
   - id: docformatter
+    language_version: python3.12
     args: [
       --in-place,
       --pre-summary-newline,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,17 +45,6 @@ Notes:
   `sudo apt install -y build-essential libxkbcommon-dev tesseract-ocr`.
   Optional: `python3-tk`. See `CONTRIBUTING.md` for the full setup guide.
 
-## Mir / Wayland caveat
-
-The Mir platform uses `os.memfd_create`, which is missing from uv-managed
-Python builds. If you need to run or test Mir/Wayland code, create the venv
-with system Python (this matches the command in `CONTRIBUTING.md`):
-
-```bash
-uv --no-managed-python venv --system-site-packages
-uv sync
-```
-
 ## Repo-specific guardrails
 
 - Line length is **79**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We can install YARF along with the dependencies specified in
 `pyproject.toml` in the virtual environment using the command:
 
 ```shell
-uv --no-managed-python venv --system-site-packages
+uv venv
 uv sync
 ```
 

--- a/docs/tutorial/writting-a-test-suite.md
+++ b/docs/tutorial/writting-a-test-suite.md
@@ -49,7 +49,10 @@ sudo apt install \
     gir1.2-adw-1
 ```
 
-After that, we install `uv` following the [official installation guide][uv-installation-guide] and run the `simple-counter`:
+After that, we install `uv` following the [official installation guide][uv-installation-guide].
+The `simple-counter` application uses the distro-provided `python3-gi` bindings,
+so use `--system-site-packages` to make them available in its environment. Then
+run the `simple-counter`:
 
 ```{code-block} bash
 ---

--- a/yarf/lib/wayland/__init__.py
+++ b/yarf/lib/wayland/__init__.py
@@ -18,7 +18,7 @@ def get_memfd() -> int:
 
     Raises:
         AssertionError: if it can't create memfd
-        SystemExit: if memfd_create is not available (uv Python build issue)
+        SystemExit: if memfd_create is not available
     """
     global memfd_counter
     memfd_counter += 1
@@ -28,10 +28,7 @@ def get_memfd() -> int:
         open_result: int = os.memfd_create(name, os.MFD_CLOEXEC)
     except AttributeError:
         raise SystemExit(
-            "os.memfd_create is not available in this Python build. "
-            + "This is a known issue with uv Python builds. "
-            + "To fix this, use system Python instead: "
-            + "`uv --no-managed-python venv --system-site-packages`"
+            "os.memfd_create is not available in this Python build."
         )
 
     assert open_result >= 0, (


### PR DESCRIPTION
## Description

Remove the system-Python workaround for YARF and Mir. The upstream `python-build-standalone` fix means uv-managed Python provides `os.memfd_create`.

Keep the project on Python 3.12 for Noble: the pinned `pywayland` release has no Python 3.14 wheel, which otherwise makes uv build it and fail because `/usr/share/wayland/wayland.xml` is unavailable. Configure the legacy `docformatter` hook to use Python 3.12 as well, since its `untokenize` dependency does not support Python 3.14.

The `simple-counter` tutorial uses `--system-site-packages` so its environment can import the distro-provided `python3-gi` bindings.

Upstream reference: https://github.com/astral-sh/python-build-standalone/pull/1164

## Resolved issues

N/A

## Documentation

- Updated the contributor guide, agent guidance, and Copilot instructions to remove the obsolete `os.memfd_create` workaround.
- Documented that `--system-site-packages` makes the distro-provided `python3-gi` bindings available to simple-counter.

## Tests

- `uv run python` created and closed a memfd successfully.
- `uv run ruff check yarf/lib/wayland/__init__.py`
- `uv lock --check`
- `prek run docformatter --all-files --show-diff-on-failure --hook-stage manual` (using Python 3.12)