### PR TITLE
[Infra] Add wayland-protocols to example plugin snap for arm64

### DIFF
--- a/examples/yarf-example-plugin/snap/snapcraft.yaml
+++ b/examples/yarf-example-plugin/snap/snapcraft.yaml
@@ -27,6 +27,9 @@ parts:
       - pkg-config
       - libxkbcommon-dev
       - libwayland-dev
+      # pywayland ships no arm64 wheel, so it is built from source there and
+      # its scanner needs the wayland-protocols pkg-config data.
+      - wayland-protocols
     stage-packages:
       - libxkbcommon0
       - bash


### PR DESCRIPTION
## Description

Follow up on #301, the example plugin failed to build because there has no pywayland arm64 wheel. So, pip install pywayland always compiles the sdist, and that sdist's build runs python -m scanner --with-protocols, which requires pkg-config wayland-protocols.

## Resolved issues

Canary test: https://github.com/canonical/yarf/actions/runs/32033818281/job/95399770083

## Documentation



## Tests


