### PR TITLE
[BugFix] Skip PR body check for Bot PRs

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -36,6 +36,8 @@ jobs:
   validate_body:
     name: Validate PR description
     runs-on: ubuntu-latest
+    # Bots (renovate, dependabot, ...) do not use the PR template.
+    if: github.event.pull_request.user.type != 'Bot'
     permissions:
       contents: read  # Required to check out repository code
       pull-requests: write  # Required to strip leftover template comments


### PR DESCRIPTION
## Description

The PR body validation CI was working, but it also checked for PRs created by bots such as Renovate.
This PR skip the check for bot PRs.

## Resolved issues

PRs like: https://github.com/canonical/yarf/pull/308

## Documentation

## Tests
